### PR TITLE
Add APIM sample deployment, and log4j & fluentbit configs for APIM logs

### DIFF
--- a/observability/dashboards/index-template-request-apim.json
+++ b/observability/dashboards/index-template-request-apim.json
@@ -1,0 +1,54 @@
+{
+    "index_patterns": [
+        "wso2-apim-application-logs-*"
+    ],
+    "template": {
+        "mappings": {
+            "properties": {
+                "kubernetes": {
+                    "type": "object",
+                    "properties": {
+                        "labels": {
+                            "type": "object",
+                            "properties": {
+                                "app": {
+                                    "type": "keyword"
+                                },
+                                "component": {
+                                    "type": "keyword"
+                                }
+                            }
+                        }
+                    }
+                },
+                "level": {
+                    "type": "keyword"
+                },
+                "time": {
+                    "type": "date"
+                },
+                "api": {
+                    "type": "keyword"
+                },
+                "message": {
+                    "type": "keyword"
+                },
+                "product": {
+                    "type": "keyword"
+                },
+                "component": {
+                    "type": "keyword"
+                },
+                "package": {
+                    "type": "keyword"
+                },
+                "log_type": {
+                    "type": "keyword"
+                },
+                "app": {
+                    "type": "keyword"
+                }
+            }
+        }
+    }
+}

--- a/observability/deployment/fluent-bit.yaml
+++ b/observability/deployment/fluent-bit.yaml
@@ -192,7 +192,23 @@ config:
             Logstash_Format On
             Logstash_DateFormat %Y-%m-%d
             Logstash_Prefix wso2-integration-application-logs
-            Match_regex ^wso2_(mi_carbon_logs|bal_logs)$ ############################################## TODO DO WE NEED TO ADD APIM LOGS SIMILARLY?
+            Match_regex ^wso2_(mi_carbon_logs|bal_logs)$
+            Port 9200
+            Replace_Dots On
+            Suppress_Type_Name On
+            tls On
+            tls.verify Off
+            Trace_Error On
+
+        [OUTPUT]
+            Name opensearch
+            Host opensearch-data
+            HTTP_Passwd admin
+            HTTP_User admin
+            Logstash_Format On
+            Logstash_DateFormat %Y-%m-%d
+            Logstash_Prefix wso2-apim-application-logs
+            Match_regex ^wso2_apim_carbon_logs$
             Port 9200
             Replace_Dots On
             Suppress_Type_Name On

--- a/observability/deployment/fluent-bit.yaml
+++ b/observability/deployment/fluent-bit.yaml
@@ -208,7 +208,7 @@ config:
             Logstash_Format On
             Logstash_DateFormat %Y-%m-%d
             Logstash_Prefix wso2-apim-application-logs
-            Match_regex ^wso2_apim_carbon_logs$
+            Match wso2_apim_carbon_logs
             Port 9200
             Replace_Dots On
             Suppress_Type_Name On

--- a/observability/deployment/fluent-bit.yaml
+++ b/observability/deployment/fluent-bit.yaml
@@ -23,6 +23,13 @@ config:
             Time_Key   time
             Time_Format %Y-%m-%d %H:%M:%S,%L
 
+        [PARSER]
+            Name   wso2apim_carbon_parser
+            Format regex
+            Regex  ^(?<log_type>[A-Z]+) \[(?<time>[0-9-]{10} [0-9:,]{12})\]\s+(?<level>[A-Z]+)\s+\{(?<module>[^}]+)\}\s*(?:\[\s*Deployed From Artifact Container:\s+(?<package>[^\]]+)\s*\]\s*)?\s*(?:-\s+\{api:(?<api>[^}]+)\})?\s*(?<message>.+)
+            Time_Key   time
+            Time_Format %Y-%m-%d %H:%M:%S,%L
+
     inputs: |
         [INPUT]
             Name tail
@@ -97,6 +104,32 @@ config:
             Preserve_Key True
 
         [FILTER]
+            Name rewrite_tag_apim
+            Match kube.*
+            Rule $kubernetes['labels']['component'] wso2apim wso2_apim_logs false
+            Emitter_Name re_emitted_apim
+
+        [FILTER]
+            Name modify_apim
+            Match wso2_apim_logs
+            Add product api-management
+            Add component apim
+
+        [FILTER]
+            Name rewrite_tag_apim
+            Match wso2_apim_logs
+            Rule $log ^CARBON wso2_apim_carbon_logs false
+            Emitter_Name re_emitted_apim_carbon
+
+        [FILTER]
+            Name parser
+            Match wso2_apim_carbon_logs
+            Key_Name log
+            Parser wso2apim_carbon_parser
+            Reserve_Data True
+            Preserve_Key True
+
+        [FILTER]
             Name rewrite_tag
             Match wso2_mi_logs
             Rule $log ^HTTP wso2_mi_http_logs false
@@ -121,6 +154,30 @@ config:
             Emitter_Name re_emitted_mi_trace
 
         [FILTER]
+            Name rewrite_tag_apim
+            Match wso2_apim_logs
+            Rule $log ^HTTP wso2_apim_http_logs false
+            Emitter_Name re_emitted_apim_http
+
+        [FILTER]
+            Name rewrite_tag_apim
+            Match wso2_apim_logs
+            Rule $log ^AUDIT wso2_apim_audit_logs false
+            Emitter_Name re_emitted_apim_audit
+
+        [FILTER]
+            Name rewrite_tag_apim
+            Match wso2_apim_logs
+            Rule $log ^CREL wso2_apim_correlation_logs false
+            Emitter_Name re_emitted_apim_correlation
+
+        [FILTER]
+            Name rewrite_tag_apim
+            Match wso2_apim_logs
+            Rule $log ^TRACE wso2_apim_trace_logs false
+            Emitter_Name re_emitted_apim_trace
+
+        [FILTER]
             Name lua
             Match wso2_*
             script /fluent-bit/scripts/copy_app_name.lua
@@ -135,7 +192,7 @@ config:
             Logstash_Format On
             Logstash_DateFormat %Y-%m-%d
             Logstash_Prefix wso2-integration-application-logs
-            Match_regex ^wso2_(mi_carbon_logs|bal_logs)$
+            Match_regex ^wso2_(mi_carbon_logs|bal_logs)$ ############################################## TODO DO WE NEED TO ADD APIM LOGS SIMILARLY?
             Port 9200
             Replace_Dots On
             Suppress_Type_Name On
@@ -166,8 +223,40 @@ config:
             HTTP_User admin
             Logstash_Format On
             Logstash_DateFormat %Y-%m-%d
+            Logstash_Prefix wso2-apim-access-logs
+            Match wso2_apim_http_logs
+            Port 9200
+            Replace_Dots On
+            Suppress_Type_Name On
+            tls On
+            tls.verify Off
+            Trace_Error On
+
+        [OUTPUT]
+            Name opensearch
+            Host opensearch-data
+            HTTP_Passwd admin
+            HTTP_User admin
+            Logstash_Format On
+            Logstash_DateFormat %Y-%m-%d
             Logstash_Prefix wso2-integration-correlation-logs
             Match wso2_mi_correlation_logs
+            Port 9200
+            Replace_Dots On
+            Suppress_Type_Name On
+            tls On
+            tls.verify Off
+            Trace_Error On
+
+        [OUTPUT]
+            Name opensearch
+            Host opensearch-data
+            HTTP_Passwd admin
+            HTTP_User admin
+            Logstash_Format On
+            Logstash_DateFormat %Y-%m-%d
+            Logstash_Prefix wso2-apim-correlation-logs
+            Match wso2_apim_correlation_logs
             Port 9200
             Replace_Dots On
             Suppress_Type_Name On
@@ -198,8 +287,40 @@ config:
             HTTP_User admin
             Logstash_Format On
             Logstash_DateFormat %Y-%m-%d
+            Logstash_Prefix wso2-apim-trace-logs
+            Match wso2_apim_trace_logs
+            Port 9200
+            Replace_Dots On
+            Suppress_Type_Name On
+            tls On
+            tls.verify Off
+            Trace_Error On
+
+        [OUTPUT]
+            Name opensearch
+            Host opensearch-data
+            HTTP_Passwd admin
+            HTTP_User admin
+            Logstash_Format On
+            Logstash_DateFormat %Y-%m-%d
             Logstash_Prefix wso2-integration-audit-logs
             Match wso2_mi_audit_logs
+            Port 9200
+            Replace_Dots On
+            Suppress_Type_Name On
+            tls On
+            tls.verify Off
+            Trace_Error On
+
+        [OUTPUT]
+            Name opensearch
+            Host opensearch-data
+            HTTP_Passwd admin
+            HTTP_User admin
+            Logstash_Format On
+            Logstash_DateFormat %Y-%m-%d
+            Logstash_Prefix wso2-apim-audit-logs
+            Match wso2_apim_audit_logs
             Port 9200
             Replace_Dots On
             Suppress_Type_Name On

--- a/samples/deployment/apim-demo/files/log4j2.properties
+++ b/samples/deployment/apim-demo/files/log4j2.properties
@@ -1,0 +1,459 @@
+# list of all appenders
+#add entry "syslog" to use the syslog appender
+appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE
+#, syslog
+
+# CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# CARBON_LOGFILE is set to be a DailyRollingFileAppender using a PatternLayout.
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# Appender config API logging
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to send Atomikos transaction logs to new log file tm.out.
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+# Appender config to CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+# Appender config to put correlation Log.
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern =${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.CARBON_SYS_LOG.type = Syslog
+appender.CARBON_SYS_LOG.name = CARBON_SYS_LOG
+appender.CARBON_SYS_LOG.host = localhost
+appender.CARBON_SYS_LOG.facility = USER
+appender.CARBON_SYS_LOG.layout.type = PatternLayout
+appender.CARBON_SYS_LOG.layout.pattern = [%d] %5p - %x %m {%c}%n
+appender.CARBON_SYS_LOG.filter.threshold.type = ThresholdFilter
+appender.CARBON_SYS_LOG.filter.threshold.level = DEBUG
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size=1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+
+logger.org-apache-coyote.name = org.apache.coyote
+logger.org-apache-coyote.level = WARN
+
+logger.com-hazelcast.name = com.hazelcast
+logger.com-hazelcast.level = ERROR
+
+logger.Owasp-CsrfGuard.name = Owasp.CsrfGuard
+logger.Owasp-CsrfGuard.level = WARN
+
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
+logger.org-apache-axis2-clustering.level = INFO
+logger.org-apache-axis2-clustering.additivity = false
+
+logger.org-apache.name = org.apache
+logger.org-apache.level = INFO
+logger.org-apache.additivity = false
+logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-catalina.name = org.apache.catalina
+logger.org-apache-catalina.level = ERROR
+
+logger.org-apache-tomcat.name = org.apache.tomcat
+logger.org-apache-tomcat.level = INFO
+
+logger.org-wso2-carbon-apacheds.name = org.wso2.carbon.apacheds
+logger.org-wso2-carbon-apacheds.level = WARN
+
+logger.org-apache-directory-server-ldap.name = org.apache.directory.server.ldap
+logger.org-apache-directory-server-ldap.level = ERROR
+
+logger.org-apache-directory-server-core-event.name = org.apache.directory.server.core.event
+logger.org-apache-directory-server-core-event.level = WARN
+
+logger.com-atomikos.name = com.atomikos
+logger.com-atomikos.level = INFO
+logger.com-atomikos.additivity = false
+logger.com-atomikos.appenderRef.ATOMIKOS_LOGFILE.ref = ATOMIKOS_LOGFILE
+
+logger.org-quartz.name = org.quartz
+logger.org-quartz.level = WARN
+
+logger.org-apache-jackrabbit-webdav.name = org.apache.jackrabbit.webdav
+logger.org-apache-jackrabbit-webdav.level = WARN
+
+logger.org-apache-juddi.name = org.apache.juddi
+logger.org-apache-juddi.level = ERROR
+
+logger.org-apache-commons-digester-Digester.name = org.apache.commons.digester.Digester
+logger.org-apache-commons-digester-Digester.level = WARN
+
+logger.org-apache-jasper-compiler-TldLocationsCache.name = org.apache.jasper.compiler.TldLocationsCache
+logger.org-apache-jasper-compiler-TldLocationsCache.level = WARN
+
+logger.org-apache-qpid.name = org.apache.qpid
+logger.org-apache-qpid.level = WARN
+
+logger.org-apache-qpid-server-Main.name = org.apache.qpid.server.Main
+logger.org-apache-qpid-server-Main.level = INFO
+
+logger.qpid-message.name = qpid.message
+logger.qpid-message.level = WARN
+
+logger.qpid-message-broker-listening.name = qpid.message.broker.listening
+logger.qpid-message-broker-listening.level = INFO
+
+logger.org-apache-tiles.name = org.apache.tiles
+logger.org-apache-tiles.level = WARN
+
+logger.org-apache-commons-httpclient.name = org.apache.commons.httpclient
+logger.org-apache-commons-httpclient.level = ERROR
+
+logger.org-apache-solr.name = org.apache.solr
+logger.org-apache-solr.level = ERROR
+
+logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
+logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
+
+logger.org-wso2.name = org.wso2
+logger.org-wso2.level = INFO
+
+logger.org-wso2-carbon.name = org.wso2.carbon
+logger.org-wso2-carbon.level = INFO
+
+logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
+logger.org-apache-axis-enterprise.level = FATAL
+logger.org-apache-axis-enterprise.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
+logger.org-apache-directory-shared-ldap.level = WARN
+logger.org-apache-directory-shared-ldap.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
+logger.org-apache-directory-server-ldap-handlers.level = WARN
+logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+# Following are to remove false error messages from startup (IS)
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
+logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
+logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-core.name = org.apache.directory.server.core
+logger.org-apache-directory-server-core.level = ERROR
+logger.org-apache-directory-server-core.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
+logger.org-apache-directory-server-ldap-LdapSession.level = Error
+logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.additivity = false
+
+# Hive Related Log configurations
+logger.DataNucleus.name = DataNucleus
+logger.DataNucleus.level = ERROR
+
+logger.Datastore.name = Datastore
+logger.Datastore.level = ERROR
+
+logger.Datastore-Schema.name = Datastore.Schema
+logger.Datastore-Schema.level = ERROR
+
+logger.JPOX-Datastore.name = JPOX.Datastore
+logger.JPOX-Datastore.level = ERROR
+
+logger.JPOX-Plugin.name = JPOX.Plugin
+logger.JPOX-Plugin.level = ERROR
+
+logger.JPOX-MetaData.name = JPOX.MetaData
+logger.JPOX-MetaData.level = ERROR
+
+logger.JPOX-Query.name = JPOX.Query
+logger.JPOX-Query.level = ERROR
+
+logger.JPOX-General.name = JPOX.General
+logger.JPOX-General.level = ERROR
+
+logger.JPOX-Enhancer.name = JPOX.Enhancer
+logger.JPOX-Enhancer.level = ERROR
+
+logger.org-apache-hadoop-hive.name = org.apache.hadoop.hive
+logger.org-apache-hadoop-hive.level = WARN
+
+logger.hive.name = hive
+logger.hive.level = WARN
+
+logger.ExecMapper.name = ExecMapper
+logger.ExecMapper.level = WARN
+
+logger.ExecReducer.name = ExecReducer
+logger.ExecReducer.level = WARN
+
+logger.net-sf-ehcache-config-ConfigurationFactory.name = net.sf.ehcache.config.ConfigurationFactory
+logger.net-sf-ehcache-config-ConfigurationFactory.level = ERROR
+
+logger.axis2Deployment.name = org.apache.axis2.deployment
+logger.axis2Deployment.level = WARN
+
+logger.equinox.name = org.eclipse.equinox
+logger.equinox.level = FATAL
+
+logger.tomcat2.name = tomcat
+logger.tomcat2.level = FATAL
+
+logger.StAXDialectDetector.name = org.apache.axiom.util.stax.dialect.StAXDialectDetector
+logger.StAXDialectDetector.level = ERROR
+
+logger.trace.name = tracer
+logger.trace.level = TRACE
+logger.trace.appenderRef.OPEN_TRACING.ref = OPEN_TRACING
+
+logger.synapse.name = org.apache.synapse
+logger.synapse.level = INFO
+
+logger.synapse_transport.name = org.apache.synapse.transport
+logger.synapse_transport.level = INFO
+
+logger.axis2.name = org.apache.axis2
+logger.axis2.level = INFO
+
+logger.axis2_transport.name = org.apache.axis2.transport
+logger.axis2_transport.level = INFO
+
+logger.hunsicker.name = de.hunsicker.jalopy.io
+logger.hunsicker.level = FATAL
+
+logger.synapse-headers.name = org.apache.synapse.transport.http.headers
+logger.synapse-headers.level = DEBUG
+
+logger.synapse-wire.name = org.apache.synapse.transport.http.wire
+logger.synapse-wire.level = DEBUG
+
+logger.thrift-publisher.name = org.wso2.carbon.databridge.agent.thrift.AsyncDataPublisher
+logger.thrift-publisher.level = WARN
+
+logger.service_logger.name = SERVICE_LOGGER
+logger.service_logger.level = INFO
+logger.service_logger.additivity = false
+logger.service_logger.appenderRef.SERVICE_APPENDER.ref = SERVICE_APPENDER
+
+logger.wso2-callhome.name = org.wso2.callhome
+logger.wso2-callhome.level = INFO
+
+logger.trace_logger.name = TRACE_LOGGER
+logger.trace_logger.level = INFO
+logger.trace_logger.appenderRef.TRACE_APPENDER.ref = TRACE_APPENDER
+
+# root loggers
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
+#rootLogger.appenderReg.CARBON_SYS_LOG.ref = CARBON_SYS_LOG
+#rootLogger.appenderRef.syslog.ref = syslog
+
+# bot detection feature appender
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.size.size = 10MB
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.name = org.wso2.carbon.apimgt.gateway.mediators.BotDetectionMediator
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.level = INFO
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.appenderRef.BOTDATA_APPENDER.ref = BOTDATA_APPENDER
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.additivity = false
+
+category.SERVICE_APPENDER._OpenService_ = TRACE_APPENDER, BOTDATA_APPENDER

--- a/samples/deployment/apim-demo/files/log4j2.properties
+++ b/samples/deployment/apim-demo/files/log4j2.properties
@@ -1,13 +1,13 @@
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, BOTDATA_APPENDER, API_LOGFILE
+appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, AUDIT_CONSOLE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_TRACE_CONSOLE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, CORRELATION_CONSOLE, BOTDATA_APPENDER, API_LOGFILE, HTTP_ACCESS, HTTP_ACCESS_CONSOLE
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
 appender.CARBON_CONSOLE.type = Console
 appender.CARBON_CONSOLE.name = CARBON_CONSOLE
 appender.CARBON_CONSOLE.layout.type = PatternLayout
-appender.CARBON_CONSOLE.layout.pattern = [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.layout.pattern = CARBON [%d{DEFAULT}] %5p - %c{1} %m%n
 appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
 appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
 
@@ -46,6 +46,14 @@ appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.AUDIT_LOGFILE.strategy.max = 20
 appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
 appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# Appender config for AUDIT_CONSOLE
+appender.AUDIT_CONSOLE.type = Console
+appender.AUDIT_CONSOLE.name = AUDIT_CONSOLE
+appender.AUDIT_CONSOLE.layout.type = PatternLayout
+appender.AUDIT_CONSOLE.layout.pattern = AUDIT TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_CONSOLE.filter.threshold.level = DEBUG
 
 # Appender config API logging
 appender.API_LOGFILE.type = RollingFile
@@ -95,6 +103,14 @@ appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
 appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.CARBON_TRACE_LOGFILE.strategy.max = 20
 
+# Appender config FOR CARBON_TRACE_CONSOLE
+appender.CARBON_TRACE_CONSOLE.type = Console
+appender.CARBON_TRACE_CONSOLE.name = CARBON_TRACE_CONSOLE
+appender.CARBON_TRACE_CONSOLE.layout.type = PatternLayout
+appender.CARBON_TRACE_CONSOLE.layout.pattern = TRACE [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_TRACE_CONSOLE.filter.threshold.level = DEBUG
+
 # Appender config to put correlation Log.
 appender.CORRELATION.type = RollingFile
 appender.CORRELATION.name = CORRELATION
@@ -112,6 +128,14 @@ appender.CORRELATION.strategy.type = DefaultRolloverStrategy
 appender.CORRELATION.strategy.max = 20
 appender.CORRELATION.filter.threshold.type = ThresholdFilter
 appender.CORRELATION.filter.threshold.level = INFO
+
+# Appender config FOR CORRELATION_CONSOLE
+appender.CORRELATION_CONSOLE.type = Console
+appender.CORRELATION_CONSOLE.name = CORRELATION_CONSOLE
+appender.CORRELATION_CONSOLE.layout.type = PatternLayout
+appender.CORRELATION_CONSOLE.layout.pattern = CREL %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CORRELATION_CONSOLE.filter.threshold.level = INFO
 
 appender.ERROR_LOGFILE.type = RollingFile
 appender.ERROR_LOGFILE.name = ERROR_LOGFILE
@@ -181,11 +205,36 @@ appender.SERVICE_APPENDER.policies.size.size=1000KB
 appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
 appender.SERVICE_APPENDER.strategy.max = 10
 
+appender.HTTP_ACCESS.type = RollingFile
+appender.HTTP_ACCESS.name = HTTP_ACCESS
+appender.HTTP_ACCESS.fileName =${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.HTTP_ACCESS.filePattern =${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}.log
+appender.HTTP_ACCESS.layout.type = PatternLayout
+appender.HTTP_ACCESS.layout.pattern = [%X{Correlation-ID}] %mm%n
+appender.HTTP_ACCESS.policies.type = Policies
+appender.HTTP_ACCESS.policies.time.type = TimeBasedTriggeringPolicy
+appender.HTTP_ACCESS.policies.time.interval = 1
+appender.HTTP_ACCESS.policies.time.modulate = true
+appender.HTTP_ACCESS.policies.size.type = SizeBasedTriggeringPolicy
+appender.HTTP_ACCESS.policies.size.size=10MB
+appender.HTTP_ACCESS.strategy.type = DefaultRolloverStrategy
+appender.HTTP_ACCESS.strategy.max = 20
+appender.HTTP_ACCESS.filter.threshold.type = ThresholdFilter
+appender.HTTP_ACCESS.filter.threshold.level = INFO
+
+# Appender config for Http access console
+appender.HTTP_ACCESS_CONSOLE.type = Console
+appender.HTTP_ACCESS_CONSOLE.name = HTTP_ACCESS_CONSOLE
+appender.HTTP_ACCESS_CONSOLE.layout.type = PatternLayout
+appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP %msg%n
+appender.HTTP_ACCESS_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.HTTP_ACCESS_CONSOLE.filter.threshold.level = DEBUG
+
 appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG
+loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG, HTTP_ACCESS
 
 logger.API_LOG.name = API_LOG
 logger.API_LOG.level = INFO
@@ -196,11 +245,19 @@ logger.API_LOG.additivity = false
 logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
 logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.appenderRef.AUDIT_CONSOLE.ref = AUDIT_CONSOLE
 logger.AUDIT_LOG.additivity = false
 
 logger.trace-messages.name = trace.messages
 logger.trace-messages.level = TRACE
 logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+logger.trace-messages.appenderRef.CARBON_TRACE_CONSOLE.ref = CARBON_TRACE_CONSOLE
+
+logger.HTTP_ACCESS.name = HTTP_ACCESS
+logger.HTTP_ACCESS.level = INFO
+logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS.ref = HTTP_ACCESS
+logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS_CONSOLE.ref = HTTP_ACCESS_CONSOLE
+logger.HTTP_ACCESS.additivity = false
 
 logger.org-apache-coyote.name = org.apache.coyote
 logger.org-apache-coyote.level = WARN
@@ -213,7 +270,7 @@ logger.Owasp-CsrfGuard.level = WARN
 
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
-logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
 logger.org-apache-axis2-clustering.level = INFO
@@ -222,7 +279,7 @@ logger.org-apache-axis2-clustering.additivity = false
 logger.org-apache.name = org.apache
 logger.org-apache.level = INFO
 logger.org-apache.additivity = false
-logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-catalina.name = org.apache.catalina
 logger.org-apache-catalina.level = ERROR
@@ -291,44 +348,45 @@ logger.org-wso2-carbon.level = INFO
 
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL
-logger.org-apache-axis-enterprise.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-axis-enterprise.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
 logger.org-apache-directory-shared-ldap.level = WARN
-logger.org-apache-directory-shared-ldap.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-shared-ldap.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
 logger.org-apache-directory-server-ldap-handlers.level = WARN
-logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 # Following are to remove false error messages from startup (IS)
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
-logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
 logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
-logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
-logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
-logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-server-core.name = org.apache.directory.server.core
 logger.org-apache-directory-server-core.level = ERROR
-logger.org-apache-directory-server-core.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-server-core.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
 logger.org-apache-directory-server-ldap-LdapSession.level = Error
-logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
 
 logger.correlation.name = correlation
 logger.correlation.level = INFO
 logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.appenderRef.CORRELATION_CONSOLE.ref = CORRELATION_CONSOLE
 logger.correlation.additivity = false
 
 # Hive Related Log configurations

--- a/samples/deployment/apim/all-in-one/Chart.yaml
+++ b/samples/deployment/apim/all-in-one/Chart.yaml
@@ -1,0 +1,17 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+appVersion: "4.3.0"
+description: A Helm chart for the deployment of WSO2 API Manager Single Node.
+name: am-all-in-one
+version: 4.3.0-1
+icon: https://wso2.cachefly.net/wso2/sites/all/images/wso2logo.svg

--- a/samples/deployment/apim/all-in-one/README.md
+++ b/samples/deployment/apim/all-in-one/README.md
@@ -1,0 +1,74 @@
+## Deploy WSO2 APIM all-in-one
+
+Run the following command from this directory.
+
+```
+helm install wso2-apim . -n observability
+```
+
+
+## Accessing APIM Publisher & DevPortal
+
+Please follow these steps to access API Manager Publisher, DevPortal consoles.
+
+1. Obtain the external IP (`EXTERNAL-IP`) of the API Manager Ingress resources, by listing down the Kubernetes Ingresses.
+
+  kubectl get ing -n observability
+
+  The output under the relevant column stands for the following.
+
+  API Manager Publisher-DevPortal
+
+  - NAME: Metadata name of the Kubernetes Ingress resource (defaults to wso2-apim-am-all-in-one-am-ingress)
+  - HOSTS: Hostname of the WSO2 API Manager service (am.wso2.com)
+  - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
+  - PORTS: Externally exposed service ports of the API Manager service
+
+  API Manager Gateway
+
+  - NAME: Metadata name of the Kubernetes Ingress resource (defaults to wso2-apim-am-all-in-one-am-gateway-ingress)
+  - HOSTS: Hostname of the WSO2 API Manager's Gateway service (gw.wso2.com)
+  - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
+  - PORTS: Externally exposed service ports of the API Manager' Gateway service
+
+
+2. Add a DNS record mapping the hostnames (in step 1) and the external IP.
+
+   If the defined hostnames (in step 1) are backed by a DNS service, add a DNS record mapping the hostnames and
+   the external IP (`EXTERNAL-IP`) in the relevant DNS service.
+
+   If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
+   hostnames and the external IP in the `/etc/hosts` file at the client-side.
+
+   <EXTERNAL-IP> am.wso2.com gw.wso2.com
+
+3. Navigate to the consoles in your browser of choice.
+
+   API Manager Publisher: https://am.wso2.com/publisher
+   API Manager DevPortal: https://am.wso2.com/devportal
+
+
+   ## Enabling Correlation Logs
+
+   Execute the following cURL command.
+   ```
+   curl -X PUT 'https://am.wso2.com/api/am/devops/v0/config/correlation' \
+    -H 'accept: application/json' \
+    -H 'Content-Type: application/json' \
+    -H 'Authorization: Basic YWRtaW46YWRtaW4=' \
+    -d '{"components":[{
+        "name":"http",
+        "enabled":"true"},
+        {
+        "name":"ldap",
+        "enabled":"false"},
+        {
+        "name":"jdbc",
+        "enabled":"false"},
+        {
+        "name":"synapse",
+        "enabled":"true"},
+        {
+        "name":"method-calls",
+        "enabled":"false"}]}' -k
+   ```

--- a/samples/deployment/apim/all-in-one/confs/api-manager.sh
+++ b/samples/deployment/apim/all-in-one/confs/api-manager.sh
@@ -1,0 +1,372 @@
+#!/bin/sh
+# ----------------------------------------------------------------------------
+#  Copyright 2005-2012 WSO2, Inc. http://www.wso2.org
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+# Main Script for the WSO2 Carbon Server
+#
+# Environment Variable Prequisites
+#
+#   CARBON_HOME   Home of WSO2 Carbon installation. If not set I will  try
+#                   to figure it out.
+#
+#   JAVA_HOME       Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS       (Optional) Java runtime options used when the commands
+#                   is executed.
+#
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
+# -----------------------------------------------------------------------------
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_VERSION" ] ; then
+             JAVA_VERSION="CurrentJDK"
+           else
+             echo "Using Java version: $JAVA_VERSION"
+           fi
+           if [ -z "$JAVA_HOME" ] ; then
+             JAVA_HOME=/System/Library/Frameworks/JavaVM.framework/Versions/${JAVA_VERSION}/Home
+           fi
+           ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+# Only set CARBON_HOME if not already set
+[ -z "$CARBON_HOME" ] && CARBON_HOME=`cd "$PRGDIR/.." ; pwd`
+
+# Set AXIS2_HOME. Needed for One Click JAR Download
+AXIS2_HOME="$CARBON_HOME"
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$CARBON_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+  [ -n "$AXIS2_HOME" ] && CARBON_HOME=`cygpath --unix "$CARBON_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$CARBON_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+  [ -n "$AXIS2_HOME" ] &&
+    CARBON_HOME="`(cd "$CARBON_HOME"; pwd)`"
+  # TODO classpath?
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  echo " CARBON cannot execute $JAVACMD"
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running CARBON."
+  exit 1
+fi
+
+if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+  PID=`cat "$CARBON_HOME"/wso2carbon.pid`
+fi
+
+# ----- Process the input command ----------------------------------------------
+args=""
+for c in $*
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+          continue
+    elif [ "$CMD" = "--debug" ]; then
+          if [ -z "$PORT" ]; then
+                PORT=$c
+          fi
+    elif [ "$c" = "--stop" ] || [ "$c" = "-stop" ] || [ "$c" = "stop" ]; then
+          CMD="stop"
+    elif [ "$c" = "--start" ] || [ "$c" = "-start" ] || [ "$c" = "start" ]; then
+          CMD="start"
+    elif [ "$c" = "--version" ] || [ "$c" = "-version" ] || [ "$c" = "version" ]; then
+          CMD="version"
+    elif [ "$c" = "--restart" ] || [ "$c" = "-restart" ] || [ "$c" = "restart" ]; then
+          CMD="restart"
+    elif [ "$c" = "--test" ] || [ "$c" = "-test" ] || [ "$c" = "test" ]; then
+          CMD="test"
+    elif [ "$c" = "--optimize" ] || [ "$c" = "-optimize" ] || [ "$c" = "optimize" ]; then
+      for option in $*; do
+        if [ "$option" = "--skipConfigOptimization" ] || [ "$option" = "-skipConfigOptimization" ] ||
+        [ "$option" = "skipConfigOptimization" ]; then
+          passedSkipConfigOptimizationOption=true
+          echo "Passed skipConfigOptimization Option: $passedSkipConfigOptimizationOption"
+        fi
+      done
+
+      for profile in $*; do
+        case "$profile" in
+          *Dprofile=*)
+            cd $(dirname "$0")
+            if [ "$passedSkipConfigOptimizationOption" = true ]; then
+              sh profileSetup.sh $profile --skipConfigOptimization
+            else
+              sh profileSetup.sh $profile
+            fi
+            echo "Starting the server..."
+            ;;
+        esac
+      done
+    else
+        args="$args $c"
+    fi
+done
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo " Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  CMD="RUN"
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+elif [ "$CMD" = "start" ]; then
+  if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
+    if  ps -p $PID > /dev/null ; then
+      echo "Process is already running"
+      exit 0
+    fi
+  fi
+  export CARBON_HOME="$CARBON_HOME"
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/api-manager.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "stop" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  exit 0
+elif [ "$CMD" = "restart" ]; then
+  export CARBON_HOME="$CARBON_HOME"
+  kill -term `cat "$CARBON_HOME"/wso2carbon.pid`
+  process_status=0
+  pid=`cat "$CARBON_HOME"/wso2carbon.pid`
+  while [ "$process_status" -eq "0" ]
+  do
+        sleep 1;
+        ps -p$pid 2>&1 > /dev/null
+        process_status=$?
+  done
+
+# using nohup sh to avoid erros in solaris OS.TODO
+  nohup sh "$CARBON_HOME"/bin/api-manager.sh $args > /dev/null 2>&1 &
+  exit 0
+elif [ "$CMD" = "test" ]; then
+    JAVACMD="exec "$JAVACMD""
+elif [ "$CMD" = "version" ]; then
+  cat "$CARBON_HOME"/bin/version.txt
+  cat "$CARBON_HOME"/bin/wso2carbon-version.txt
+  exit 0
+fi
+
+# ---------- Handle the SSL Issue with proper JDK version --------------------
+java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
+if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 2100 ]; then
+   echo " Starting WSO2 Carbon (in unsupported JDK)"
+   echo " [ERROR] CARBON is supported only between JDK 11 and JDK 21"
+fi
+
+CARBON_XBOOTCLASSPATH=""
+for f in "$CARBON_HOME"/lib/xboot/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/lib/xboot/*.jar" ];then
+        CARBON_XBOOTCLASSPATH="$CARBON_XBOOTCLASSPATH":$f
+    fi
+done
+
+
+CARBON_CLASSPATH=""
+if [ -e "$JAVA_HOME/lib/tools.jar" ]; then
+    CARBON_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+for f in "$CARBON_HOME"/bin/*.jar
+do
+    if [ "$f" != "$CARBON_HOME/bin/*.jar" ];then
+        CARBON_CLASSPATH="$CARBON_CLASSPATH":$f
+    fi
+done
+for t in "$CARBON_HOME"/lib/*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+for t in "$CARBON_HOME"/lib/endorsed/*.jar
+do
+    CARBON_CLASSPATH="$CARBON_CLASSPATH":$t
+done
+
+
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  CARBON_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  AXIS2_HOME=`cygpath --absolute --windows "$CARBON_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  CARBON_CLASSPATH=`cygpath --path --windows "$CARBON_CLASSPATH"`
+  CARBON_XBOOTCLASSPATH=`cygpath --path --windows "$CARBON_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+
+echo JAVA_HOME environment variable is set to $JAVA_HOME
+echo CARBON_HOME environment variable is set to "$CARBON_HOME"
+
+cd "$CARBON_HOME"
+
+TMP_DIR="$CARBON_HOME"/tmp
+if [ -d "$TMP_DIR" ]; then
+rm -rf "$TMP_DIR"/*
+fi
+
+START_EXIT_STATUS=121
+status=$START_EXIT_STATUS
+
+if [ -z "$JVM_MEM_OPTS" ]; then
+   java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
+   JVM_MEM_OPTS="-Xms256m -Xmx1024m"
+   if [ "$java_version" \< "1.8" ]; then
+      JVM_MEM_OPTS="$JVM_MEM_OPTS -XX:MaxPermSize=256m"
+   fi
+fi
+echo "Using Java memory options: $JVM_MEM_OPTS"
+
+#To monitor a Carbon server in remote JMX mode on linux host machines, set the below system property.
+#   -Djava.rmi.server.hostname="your.IP.goes.here"
+
+JAVA_VER_BASED_OPTS="--add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.base/java.io=ALL-UNNAMED --add-opens java.xml/com.sun.org.apache.xerces.internal.dom=ALL-UNNAMED "
+
+if [ $java_version_formatted -ge 1700 ]; then
+    JAVA_VER_BASED_OPTS="$JAVA_VER_BASED_OPTS --add-opens=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/sun.security.x509=ALL-UNNAMED"
+fi
+
+# start diagnostic tool in background in diagnostic-tool/bin/diagnostic
+"$CARBON_HOME"/diagnostics-tool/bin/diagnostics.sh &
+diagnostic_tool_pid=$!
+
+# trap signals so we can shutdown the diagnostic tool
+cleanup() {
+    kill "$diagnostic_tool_pid"
+}
+trap 'cleanup' EXIT INT
+
+while [ "$status" = "$START_EXIT_STATUS" ]
+do
+    $JAVACMD \
+    -Xbootclasspath/a:"$CARBON_XBOOTCLASSPATH" \
+    $JVM_MEM_OPTS \
+    -XX:+HeapDumpOnOutOfMemoryError \
+    -XX:HeapDumpPath="$CARBON_HOME/repository/logs/heap-dump.hprof" \
+    $JAVA_OPTS \
+    -Dcom.sun.management.jmxremote \
+    -classpath "$CARBON_CLASSPATH" \
+    $JAVA_VER_BASED_OPTS \
+    -Djava.io.tmpdir="$CARBON_HOME/tmp" \
+    -Dcatalina.base="$CARBON_HOME/lib/tomcat" \
+    -Dwso2.server.standalone=true \
+    -Dcarbon.registry.root=/ \
+    -Djava.command="$JAVACMD" \
+    -Dcarbon.home="$CARBON_HOME" \
+    -Djava.util.logging.manager=org.apache.juli.ClassLoaderLogManager \
+    -Dcarbon.config.dir.path="$CARBON_HOME/repository/conf" \
+    -Djava.util.logging.config.file="$CARBON_HOME/repository/conf/etc/logging-bridge.properties" \
+    -Dcomponents.repo="$CARBON_HOME/repository/components/plugins" \
+    -Dconf.location="$CARBON_HOME/repository/conf"\
+    -Dcom.atomikos.icatch.file="$CARBON_HOME/lib/transactions.properties" \
+    -Dcom.atomikos.icatch.hide_init_file_path=true \
+    -Dorg.apache.jasper.compiler.Parser.STRICT_QUOTE_ESCAPING=false \
+    -Dorg.apache.jasper.runtime.BodyContentImpl.LIMIT_BUFFER=true \
+    -Dcom.sun.jndi.ldap.connect.pool.authentication=simple  \
+    -Dcom.sun.jndi.ldap.connect.pool.timeout=3000  \
+    -Dorg.terracotta.quartz.skipUpdateCheck=true \
+    -Djava.security.egd=file:/dev/./urandom \
+    -Dfile.encoding=UTF8 \
+    -Djava.net.preferIPv4Stack=true \
+    -Dcom.ibm.cacheLocalHost=true \
+    -Dorg.opensaml.httpclient.https.disableHostnameVerification=true \
+    -Dhttpclient.hostnameVerifier=AllowAll \
+    -DworkerNode=false \
+    -DenableCorrelationLogs=true \
+    -Dcarbon.new.config.dir.path="$CARBON_HOME/repository/resources/conf" \
+    -Djavax.xml.xpath.XPathFactory:http://java.sun.com/jaxp/xpath/dom=net.sf.saxon.xpath.XPathFactoryImpl \
+    -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector \
+    -Dorg.ops4j.pax.logging.logReaderEnabled=false \
+    -Dorg.ops4j.pax.logging.eventAdminEnabled=false \
+    -Djdk.util.zip.disableZip64ExtraFieldValidation=true \
+    -Djdk.nio.zipfs.allowDotZipEntry=true \
+    org.wso2.carbon.bootstrap.Bootstrap $*
+    status=$?
+done

--- a/samples/deployment/apim/all-in-one/confs/deployment.toml
+++ b/samples/deployment/apim/all-in-one/confs/deployment.toml
@@ -1,0 +1,451 @@
+[server]
+hostname = "{{ .Values.kubernetes.ingress.management.hostname }}"
+node_ip = "$env{NODE_IP}"
+offset = {{ .Values.wso2.apim.portOffset }}
+mode = "single" #single or ha
+base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
+#discard_empty_caches = false
+server_role = "default"
+
+[http_access_log]
+enabled = true
+
+[user_store]
+type = {{ .Values.wso2.apim.configurations.userStore.type | quote }}
+{{- range $key, $value := .Values.wso2.apim.configurations.userStore.properties }}
+{{ $key }} = {{ $value | quote }}
+{{- end }}
+
+[super_admin]
+username = {{ .Values.wso2.apim.configurations.adminUsername | quote }}
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{admin_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.adminPassword | quote }}
+{{- end }}
+create_admin_account = true
+
+[database.apim_db]
+type = "{{ .Values.wso2.apim.configurations.databases.type }}"
+url = "{{ .Values.wso2.apim.configurations.databases.apim_db.url}}"
+username = "{{ .Values.wso2.apim.configurations.databases.apim_db.username }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{apim_db_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.databases.apim_db.password | quote }}
+{{- end }}
+driver = "{{ .Values.wso2.apim.configurations.databases.jdbc.driver }}"
+
+[database.apim_db.pool_options]
+{{- range $key, $value := .Values.wso2.apim.configurations.databases.apim_db.poolParameters }}
+{{ $key }} = "{{ $value }}"
+{{- end }}
+
+[database.shared_db]
+type = "{{ .Values.wso2.apim.configurations.databases.type }}"
+url = "{{ .Values.wso2.apim.configurations.databases.shared_db.url}}"
+username = "{{ .Values.wso2.apim.configurations.databases.shared_db.username }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{shared_db_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.databases.shared_db.password | quote }}
+{{- end }}
+driver = "{{ .Values.wso2.apim.configurations.databases.jdbc.driver }}"
+
+[database.shared_db.pool_options]
+{{- range $key, $value := .Values.wso2.apim.configurations.databases.shared_db.poolParameters }}
+{{ $key }} = "{{ $value }}"
+{{- end }}
+
+[apim]
+gateway_type = "{{ .Values.wso2.apim.configurations.gatewayType }}"
+
+{{- if .Values.wso2.apim.configurations.security.keystores.primary.enabled }}
+[keystore.primary]
+type = "JKS"
+file_name = "{{ .Values.wso2.apim.configurations.security.keystores.primary.name }}"
+alias = "{{ .Values.wso2.apim.configurations.security.keystores.primary.alias }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{keystore_password}"
+key_password = "$secret{keystore_key_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.security.keystores.primary.password | quote }}
+key_password = {{ .Values.wso2.apim.configurations.security.keystores.primary.keyPassword | quote }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.wso2.apim.configurations.security.keystores.tls.enabled }}
+[keystore.tls]
+type = "JKS"
+file_name = "{{ .Values.wso2.apim.configurations.security.keystores.tls.name }}"
+alias = "{{ .Values.wso2.apim.configurations.security.keystores.tls.alias }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{ssl_keystore_password}"
+key_password = "$secret{ssl_key_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.security.keystores.tls.password | quote }}
+key_password = {{ .Values.wso2.apim.configurations.security.keystores.tls.keyPassword | quote }}
+{{- end }}
+{{- end }}
+
+{{- if .Values.wso2.apim.configurations.security.keystores.internal.enabled }}
+[keystore.internal]  
+type = "JKS"
+file_name = "{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}"
+alias = "{{ .Values.wso2.apim.configurations.security.keystores.internal.alias }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{internal_keystore_password}"
+key_password = "$secret{internal_keystore_key_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.security.keystores.internal.password | quote }}
+key_password = {{ .Values.wso2.apim.configurations.security.keystores.internal.keyPassword | quote }}
+{{- end }}
+{{- end }}
+
+[truststore]
+type = "JKS"
+file_name = "{{ .Values.wso2.apim.configurations.security.truststore.name }}"
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+password = "$secret{truststore_password}"
+{{- else }}
+password = {{ .Values.wso2.apim.configurations.security.truststore.password | quote }}
+{{- end }}
+
+{{- range $i, $env := .Values.wso2.apim.configurations.gateway.environments }}
+[[apim.gateway.environment]]
+name = {{ $env.name | quote }}
+type = {{ $env.type | quote }}
+gateway_type = {{ $env.gatewayType | quote }}
+provider = {{ $env.provider | quote }}
+display_in_api_console = {{ $env.displayInApiConsole }}
+description = {{ $env.description | quote }}
+show_as_token_endpoint_url = {{ $env.showAsTokenEndpointUrl }}
+service_url = "https://{{ $env.serviceName }}:{{ $env.servicePort }}/services/"
+username= "${admin.username}"
+password= "${admin.password}"
+ws_endpoint = "ws://{{ $env.wsHostname }}"
+wss_endpoint = "wss://{{ $env.wsHostname }}"
+http_endpoint = "http://{{ $env.httpHostname }}"
+https_endpoint = "https://{{ $env.httpHostname }}"
+websub_event_receiver_http_endpoint = "http://{{ $env.websubHostname }}"
+websub_event_receiver_https_endpoint = "https://{{ $env.websubHostname }}"
+{{- end }}
+
+[apim.sync_runtime_artifacts.gateway]
+gateway_labels = {{ toJson .Values.wso2.apim.configurations.syncRuntimeArtifacts.gateway.labels }}
+
+# Caches
+[apim.cache.gateway_token]
+enable = {{ .Values.wso2.apim.configurations.cache.gateway_token.enabled }}
+expiry_time = {{ .Values.wso2.apim.configurations.cache.gateway_token.expiryTime | quote }}
+
+[apim.cache.resource]
+enable = {{ .Values.wso2.apim.configurations.cache.resource.enabled }}
+expiry_time = {{ .Values.wso2.apim.configurations.cache.resource.expiryTime | quote }}
+
+[apim.cache.km_token]
+enable = {{ .Values.wso2.apim.configurations.cache.km_token.enabled }}
+expiry_time = {{ .Values.wso2.apim.configurations.cache.km_token.expiryTime | quote }}
+
+[apim.cache.recent_apis]
+enable = {{ .Values.wso2.apim.configurations.cache.recent_apis.enabled }}
+
+[apim.cache.scopes]
+enable = {{ .Values.wso2.apim.configurations.cache.scopes.enabled }}
+
+[apim.cache.publisher_roles]
+enable = {{ .Values.wso2.apim.configurations.cache.publisher_roles.enabled }}
+
+[apim.cache.jwt_claim]
+enable = {{ .Values.wso2.apim.configurations.cache.jwt_claim.enabled }}
+expiry_time = {{ .Values.wso2.apim.configurations.cache.jwt_claim.expiryTime | quote }}
+
+[apim.cache.tags]
+enable = {{ .Values.wso2.apim.configurations.cache.tags.enabled }}
+expiry_time = {{ .Values.wso2.apim.configurations.cache.tags.expiryTime | quote }}
+
+[apim.analytics]
+{{- if .Values.wso2.choreoAnalytics.enabled }}
+enable = true
+config_endpoint = "{{ .Values.wso2.choreoAnalytics.endpoint }}"
+auth_token = "{{ .Values.wso2.choreoAnalytics.onpremKey }}"
+{{- else if .Values.wso2.ELKAnalytics.enabled}}
+enable = true
+type = "elk"
+{{- else }}
+enable = false
+{{- end }}
+
+[apim.ai]
+{{- if .Values.wso2.apim.configurations.ai.enabled }}
+enable = true
+token = {{ .Values.wso2.apim.configurations.ai.token | quote }}
+endpoint = {{ .Values.wso2.apim.configurations.ai.endpoint | quote }}
+{{- else }}
+enable = false
+{{- end }}
+
+[transport.http]
+properties.port = 9763
+properties.proxyPort = 80
+
+[transport.https]
+properties.port = 9443
+properties.proxyPort = 443
+
+# key manager implementation
+[apim.key_manager]
+{{- if .Values.wso2.apim.configurations.iskm.enabled }}
+type = "WSO2-IS"
+server_url = "https://{{ .Values.wso2.apim.configurations.iskm.serviceName }}:9443/services/"
+{{- else }}
+service_url = "https://{{ template "am-all-in-one.fullname" . }}-am-service:${mgt.transport.https.port}/services/"
+{{- end }}
+username= "$ref{super_admin.username}"
+password= "$ref{super_admin.password}"
+
+[oauth.grant_type.token_exchange]
+{{- if .Values.wso2.apim.configurations.iskm.enabled }}
+enable = false
+{{- else }}
+enable = true
+{{- end }}
+allow_refresh_tokens = true
+iat_validity_period = "1h"
+
+[oauth.endpoints]
+{{- if .Values.wso2.apim.configurations.oauth_config }}
+oauth2_jwks_url = "{{ .Values.wso2.apim.configurations.oauth_config.oauth2JWKSUrl }}"
+{{- end }}
+
+#[apim.idp]
+#server_url = "https://localhost:${mgt.transport.https.port}"
+#authorize_endpoint = "https://localhost:${mgt.transport.https.port}/oauth2/authorize"
+#oidc_logout_endpoint = "https://localhost:${mgt.transport.https.port}/oidc/logout"
+#oidc_check_session_endpoint = "https://localhost:${mgt.transport.https.port}/oidc/checksession"
+
+# JWT Generation
+{{- if .Values.wso2.apim.configurations.jwt.enabled }}
+[apim.jwt]
+enable = {{ .Values.wso2.apim.configurations.jwt.enabled }}
+encoding = {{ .Values.wso2.apim.configurations.jwt.encoding | quote }} # base64,base64url
+generator_impl = {{ .Values.wso2.apim.configurations.jwt.generatorImpl | quote }}
+claim_dialect = {{ .Values.wso2.apim.configurations.jwt.claimDialect | quote }}
+header = {{ .Values.wso2.apim.configurations.jwt.header | quote }}
+signing_algorithm = {{ .Values.wso2.apim.configurations.jwt.signingAlgorithm | quote }}
+enable_user_claims = {{ .Values.wso2.apim.configurations.jwt.enableUserClaims }}
+claims_extractor_impl = {{ .Values.wso2.apim.configurations.jwt.claimsExtractorImpl | quote }}
+{{- end }}
+
+[apim.oauth_config]
+remove_outbound_auth_header = {{ .Values.wso2.apim.configurations.oauth_config.removeOutboundAuthHeader }}
+auth_header = {{ .Values.wso2.apim.configurations.oauth_config.authHeader | quote }}
+revoke_endpoint = {{ .Values.wso2.apim.configurations.oauth_config.revokeEndpoint | quote }}
+enable_token_encryption = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenEncryption }}
+enable_token_hashing = {{ .Values.wso2.apim.configurations.oauth_config.enableTokenHashing }}
+
+[apim.devportal]
+url = "https://{{ .Values.kubernetes.ingress.management.hostname }}/devportal"
+{{- if .Values.wso2.apim.configurations.devportal.enableApplicationSharing }}
+enable_application_sharing = {{ .Values.wso2.apim.configurations.devportal.enableApplicationSharing }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.applicationSharingType }}
+application_sharing_type = {{ .Values.wso2.apim.configurations.devportal.applicationSharingType | quote }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.applicationSharingImpl }}
+application_sharing_impl = {{ .Values.wso2.apim.configurations.devportal.applicationSharingImpl | quote }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.displayMultipleVersions }}
+display_multiple_versions = {{ .Values.wso2.apim.configurations.devportal.displayMultipleVersions }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.displayDeprecatedAPIs }}
+display_deprecated_apis = {{ .Values.wso2.apim.configurations.devportal.displayDeprecatedAPIs }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableComments }}
+enable_comments = {{ .Values.wso2.apim.configurations.devportal.enableComments }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableRatings }}
+enable_ratings = {{ .Values.wso2.apim.configurations.devportal.enableRatings }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableForum }}
+enable_forum = {{ .Values.wso2.apim.configurations.devportal.enableForum }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableAnonymousMode }}
+enable_anonymous_mode = {{ .Values.wso2.apim.configurations.devportal.enableAnonymousMode }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableCrossTenantSubscriptions }}
+enable_cross_tenant_subscriptions = {{ .Values.wso2.apim.configurations.devportal.enableCrossTenantSubscriptions }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.defaultReservedUsername }}
+default_reserved_username = {{ .Values.wso2.apim.configurations.devportal.defaultReservedUsername | quote }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.loginUsernameCaseInsensitive }}
+login_username_case_insensitive = {{ .Values.wso2.apim.configurations.devportal.loginUsernameCaseInsensitive }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.devportal.enableKeyProvisioning }}
+enable_key_provisioning = {{ .Values.wso2.apim.configurations.devportal.enableKeyProvisioning }}
+{{- end }}
+
+[apim.publisher]
+{{- if .Values.wso2.apim.configurations.publisher.supportedDocumentTypes }}
+supported_document_types = {{ toJson .Values.wso2.apim.configurations.publisher.supportedDocumentTypes }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.publisher.enablePortalConfigurationOnlyMode }}
+enable_portal_configuration_only_mode = {{ .Values.wso2.apim.configurations.publisher.enablePortalConfigurationOnlyMode }}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.publisher.internalKeyIssuer }}
+internal_key_issuer = "{{ .Values.wso2.apim.configurations.publisher.internalKeyIssuer }}"
+{{- end }}
+
+[apim.cors]
+enable = {{ .Values.wso2.apim.configurations.cors.enabled }}
+allow_origins = {{ toJson .Values.wso2.apim.configurations.cors.allowOrigins }}
+allow_methods = {{ toJson .Values.wso2.apim.configurations.cors.allowMethods }}
+allow_headers = {{ toJson .Values.wso2.apim.configurations.cors.allowHeaders }}
+allow_credentials = {{ .Values.wso2.apim.configurations.cors.allowCredentials }}
+enable_validation_for_ws = {{ .Values.wso2.apim.configurations.cors.enableForWS }}
+
+# [apim.throttling]
+# enable_data_publishing = {{ .Values.wso2.apim.configurations.throttling.enableDataPublishing }}
+# enable_policy_deploy = {{ .Values.wso2.apim.configurations.throttling.enablePolicyDeploy }}
+# enable_blacklist_condition = {{ .Values.wso2.apim.configurations.throttling.enableBlacklistCondition }}
+# enable_persistence = {{ .Values.wso2.apim.configurations.throttling.enablePersistence }}
+# throttle_decision_endpoints = ["tcp://{{ template "am-all-in-one.fullname" . }}-am-1-service:5672","tcp://{{ template "am-all-in-one.fullname" . }}-am-2-service:5672"]
+# enable_unlimited_tier = {{ .Values.wso2.apim.configurations.throttling.enableUnlimitedTier }}
+# enable_header_based_throttling = {{ .Values.wso2.apim.configurations.throttling.enableHeaderBasedThrottling }}
+# enable_jwt_claim_based_throttling = {{ .Values.wso2.apim.configurations.throttling.enableJWTClaimBasedThrottling }}
+# enable_query_param_based_throttling = {{ .Values.wso2.apim.configurations.throttling.enableQueryParamBasedThrottling }}
+ 
+[apim.throttling.blacklist_condition]
+{{- if .Values.wso2.apim.configurations.throttling.blacklistCondition.startDelay }}
+start_delay = {{ .Values.wso2.apim.configurations.throttling.blacklistCondition.startDelay}}
+{{- end }}
+{{- if .Values.wso2.apim.configurations.throttling.blacklistCondition.period }}
+period = {{ .Values.wso2.apim.configurations.throttling.blacklistCondition.period}}
+{{- end }}
+
+{{- if .Values.wso2.apim.configurations.throttling.jms.startDelay }}
+[apim.throttling.jms]
+start_delay = {{ .Values.wso2.apim.configurations.throttling.jms.startDelay}}
+{{- end }}
+
+{{- if .Values.wso2.apim.configurations.throttling.eventSync.hostName }}
+[apim.throttling.event_sync]
+hostName = {{ .Values.wso2.apim.configurations.throttling.eventSync.hostName}}
+port = {{ .Values.wso2.apim.configurations.throttling.eventSync.port}}
+{{- end }}
+
+{{- if .Values.wso2.apim.configurations.throttling.eventManagement.hostName }}
+[apim.throttling.event_management]
+hostName = {{ .Values.wso2.apim.configurations.throttling.eventManagement.hostName}}
+port = {{ .Values.wso2.apim.configurations.throttling.eventManagement.port}}
+{{- end }}
+
+# [[apim.throttling.url_group]]
+# traffic_manager_urls = ["tcp://{{ template "am-all-in-one.fullname" . }}-am-service:9611"]
+# traffic_manager_auth_urls = ["ssl://{{ template "am-all-in-one.fullname" . }}-am-service:9711"]
+# type = "loadbalance"
+
+# [[apim.throttling.url_group]]
+# traffic_manager_urls = ["tcp://{{ template "am-all-in-one.fullname" . }}-am-service:9611"]
+# traffic_manager_auth_urls = ["ssl://{{ template "am-all-in-one.fullname" . }}-am-service:9711"]
+# type = "failover"
+
+{{- if .Values.wso2.apim.configurations.workflow.enable }}
+[apim.workflow]
+enable = {{ .Values.wso2.apim.configurations.workflow.enable }}
+service_url = {{ .Values.wso2.apim.configurations.workflow.serviceUrl | quote }}
+username = "$ref{super_admin.username}"
+password = "$ref{super_admin.password}"
+callback_endpoint = {{ .Values.wso2.apim.configurations.workflow.callbackEndpoint | quote }}
+token_endpoint = {{ .Values.wso2.apim.configurations.workflow.tokenEndpoint | quote }}
+client_registration_endpoint = {{ .Values.wso2.apim.configurations.workflow.clientRegistrationEndpoint | quote }}
+client_registration_username = "$ref{super_admin.username}"
+client_registration_password = "$ref{super_admin.password}"
+{{- end }}
+
+# Data Bridge Configuration
+# [transport.receiver]
+# type = {{ .Values.wso2.apim.configurations.transport.receiver.type }}
+# worker_threads = {{ .Values.wso2.apim.configurations.transport.receiver.workerThreads }}
+# session_timeout = {{ .Values.wso2.apim.configurations.transport.receiver.sessionTimeout | quote }}
+# keystore.file_name = "$ref{keystore.tls.file_name}"
+# keystore.password = "$ref{keystore.tls.password}"
+# tcp_port = {{ .Values.wso2.apim.configurations.transport.receiver.tcpPort }}
+# ssl_port = {{ .Values.wso2.apim.configurations.transport.receiver.sslPort }}
+# ssl_receiver_thread_pool_size = {{ .Values.wso2.apim.configurations.transport.receiver.sslReceiverThreadPoolSize }}
+# tcp_receiver_thread_pool_size = {{ .Values.wso2.apim.configurations.transport.receiver.tcpReceiverThreadPoolSize }}
+# ssl_enabled_protocols = [{{- .Values.wso2.apim.configurations.transport.receiver.sslEnabledProtocols | join "\",\"" }}]
+# ciphers = [{{- .Values.wso2.apim.configurations.transport.receiver.ciphers | join "\",\"" }}]
+
+{{- if .Values.wso2.apim.configurations.notification.hostname }}
+[apim.notification]
+from_address = "{{ .Values.wso2.apim.configurations.notification.fromAddress }}"
+username = "{{ .Values.wso2.apim.configurations.notification.username }}"
+password = "{{ .Values.wso2.apim.configurations.notification.password }}"
+signature = "{{ .Values.wso2.apim.configurations.notification.signature }}"
+hostname = "{{ .Values.wso2.apim.configurations.notification.hostname }}"
+port = {{ .Values.wso2.apim.configurations.notification.port }}
+enable_start_tls = {{ .Values.wso2.apim.configurations.notification.enableStartTls }}
+enable_authentication = {{ .Values.wso2.apim.configurations.notification.enableAuthentication }}
+{{- end }}
+
+# [apim.token.revocation]
+# notifier_impl = "{{ .Values.wso2.apim.configurations.token.revocation.NotifierImpl }}"
+# enable_realtime_notifier = {{ .Values.wso2.apim.configurations.token.revocation.EnableRealtimeNotifier }}
+# realtime_notifier_ttl = {{ .Values.wso2.apim.configurations.token.revocation.RealtimeNotifierTtl }}
+# enable_persistent_notifier = {{ .Values.wso2.apim.configurations.token.revocation.EnablePersistentNotifier }}
+# persistent_notifier_hostname = "{{ .Values.wso2.apim.configurations.token.revocation.PersistentNotifierHostname }}"
+# persistent_notifier_ttl = {{ .Values.wso2.apim.configurations.token.revocation.PersistentNotifierTtl }}
+# persistent_notifier_username = "{{ .Values.wso2.apim.configurations.token.revocation.PersistentNotifierUsername }}"
+# persistent_notifier_password = "{{ .Values.wso2.apim.configurations.token.revocation.PersistentNotifierPassword }}"
+
+{{- range .Values.wso2.apim.configurations.eventHandlers }}
+[[event_handler]]
+name = "{{ .name }}"
+subscriptions = [{{ range .subscriptions }}"{{ . }}", {{ end }}]
+{{- end }}
+
+[service_provider]
+sp_name_regex = {{ .Values.wso2.apim.configurations.serviceProvider.spNameRegex | quote }}
+
+{{- if not .Values.wso2.apim.configurations.iskm.enabled }}
+{{ range .Values.wso2.apim.configurations.eventListeners }}
+[[event_listener]]
+id = "{{ .id }}"
+type = "{{ .type }}"
+name = "{{ .name }}"
+order = {{ .order }}
+
+[event_listener.properties]
+notification_endpoint = "https://{{ template "am-all-in-one.fullname" $ }}-am-service:${mgt.transport.https.port}/internal/data/v1/notify"
+username = "${admin.username}"
+password = "${admin.password}"
+'header.X-WSO2-KEY-MANAGER' = "default"
+{{- end }}
+{{- end }}
+
+{{- if .Values.wso2.deployment.persistence.solrIndexing.enabled }}
+[database.local]
+url = "jdbc:h2:/home/wso2carbon/solr/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+
+[indexing]
+location = "/home/wso2carbon/solr/indexed-data"
+{{- else }}
+[database.local]
+url = "jdbc:h2:./repository/database/WSO2CARBON_DB;DB_CLOSE_ON_EXIT=FALSE"
+{{- end }}
+
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+[secrets]
+admin_password = {{ .Values.wso2.apim.configurations.adminPassword | quote }}
+keystore_password = {{ .Values.wso2.apim.configurations.security.keystores.primary.password | quote }}
+keystore_key_password = {{ .Values.wso2.apim.configurations.security.keystores.primary.keyPassword | quote }}
+ssl_keystore_password = {{ .Values.wso2.apim.configurations.security.keystores.tls.password | quote }}
+ssl_key_password = {{ .Values.wso2.apim.configurations.security.keystores.tls.keyPassword | quote }}
+internal_keystore_password = {{ .Values.wso2.apim.configurations.security.keystores.internal.password | quote }}
+internal_keystore_key_password = {{ .Values.wso2.apim.configurations.security.keystores.internal.keyPassword | quote }}
+truststore_password = {{ .Values.wso2.apim.configurations.security.truststore.password | quote }}
+apim_db_password = {{ .Values.wso2.apim.configurations.databases.apim_db.password | quote }}
+shared_db_password = {{ .Values.wso2.apim.configurations.databases.shared_db.password | quote}}
+{{- end}}

--- a/samples/deployment/apim/all-in-one/confs/log4j2.properties
+++ b/samples/deployment/apim/all-in-one/confs/log4j2.properties
@@ -1,0 +1,518 @@
+# list of all appenders
+#add entry "syslog" to use the syslog appender
+appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, AUDIT_CONSOLE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_TRACE_CONSOLE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, CORRELATION_CONSOLE, BOTDATA_APPENDER, API_LOGFILE, HTTP_ACCESS, HTTP_ACCESS_CONSOLE
+#, syslog
+
+# CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
+appender.CARBON_CONSOLE.type = Console
+appender.CARBON_CONSOLE.name = CARBON_CONSOLE
+appender.CARBON_CONSOLE.layout.type = PatternLayout
+appender.CARBON_CONSOLE.layout.pattern = CARBON [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
+
+# CARBON_LOGFILE is set to be a DailyRollingFileAppender using a PatternLayout.
+appender.CARBON_LOGFILE.type = RollingFile
+appender.CARBON_LOGFILE.name = CARBON_LOGFILE
+appender.CARBON_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.CARBON_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}-%i.log
+appender.CARBON_LOGFILE.layout.type = PatternLayout
+appender.CARBON_LOGFILE.layout.pattern = TID: [%tenantId] [%appName] [%d] %5p {%c} - %m%ex%n
+appender.CARBON_LOGFILE.policies.type = Policies
+appender.CARBON_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.time.interval = 1
+appender.CARBON_LOGFILE.policies.time.modulate = true
+appender.CARBON_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_LOGFILE.policies.size.size = 10MB
+appender.CARBON_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_LOGFILE.strategy.max = 20
+appender.CARBON_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.CARBON_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.type = RollingFile
+appender.AUDIT_LOGFILE.name = AUDIT_LOGFILE
+appender.AUDIT_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/audit.log
+appender.AUDIT_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/audit-%d{MM-dd-yyyy}.log
+appender.AUDIT_LOGFILE.layout.type = PatternLayout
+appender.AUDIT_LOGFILE.layout.pattern = TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_LOGFILE.policies.type = Policies
+appender.AUDIT_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.time.interval = 1
+appender.AUDIT_LOGFILE.policies.time.modulate = true
+appender.AUDIT_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.AUDIT_LOGFILE.policies.size.size = 10MB
+appender.AUDIT_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.AUDIT_LOGFILE.strategy.max = 20
+appender.AUDIT_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_LOGFILE.filter.threshold.level = INFO
+
+# Appender config for AUDIT_CONSOLE
+appender.AUDIT_CONSOLE.type = Console
+appender.AUDIT_CONSOLE.name = AUDIT_CONSOLE
+appender.AUDIT_CONSOLE.layout.type = PatternLayout
+appender.AUDIT_CONSOLE.layout.pattern = AUDIT TID: [%tenantId] [%d] %5p {%c} - %m%ex%n
+appender.AUDIT_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.AUDIT_CONSOLE.filter.threshold.level = DEBUG
+
+# Appender config API logging
+appender.API_LOGFILE.type = RollingFile
+appender.API_LOGFILE.name = API_LOGFILE
+appender.API_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/api.log
+appender.API_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/api-%d{MM-dd-yyyy}-%i.log
+appender.API_LOGFILE.layout.type = PatternLayout
+appender.API_LOGFILE.layout.pattern = [%d] %5p {%c} %X{apiName} - %m%ex%n
+appender.API_LOGFILE.policies.type = Policies
+appender.API_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.time.interval = 1
+appender.API_LOGFILE.policies.time.modulate = true
+appender.API_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.API_LOGFILE.policies.size.size = 10MB
+appender.API_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.API_LOGFILE.strategy.max = 20
+appender.API_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.API_LOGFILE.filter.threshold.level = DEBUG
+
+# Appender config to send Atomikos transaction logs to new log file tm.out.
+appender.ATOMIKOS_LOGFILE.type = RollingFile
+appender.ATOMIKOS_LOGFILE.name = ATOMIKOS_LOGFILE
+appender.ATOMIKOS_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/tm.out
+appender.ATOMIKOS_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/tm-%d{MM-dd-yyyy}.out
+appender.ATOMIKOS_LOGFILE.layout.type = PatternLayout
+appender.ATOMIKOS_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.ATOMIKOS_LOGFILE.policies.type = Policies
+appender.ATOMIKOS_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ATOMIKOS_LOGFILE.policies.time.interval = 1
+appender.ATOMIKOS_LOGFILE.policies.time.modulate = true
+appender.ATOMIKOS_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ATOMIKOS_LOGFILE.strategy.max = 20
+
+# Appender config to CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.type = RollingFile
+appender.CARBON_TRACE_LOGFILE.name = CARBON_TRACE_LOGFILE
+appender.CARBON_TRACE_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages.log
+appender.CARBON_TRACE_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2carbon-trace-messages-%d{MM-dd-yyyy}.log
+appender.CARBON_TRACE_LOGFILE.layout.type = PatternLayout
+appender.CARBON_TRACE_LOGFILE.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_LOGFILE.policies.type = Policies
+appender.CARBON_TRACE_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.time.interval = 1
+appender.CARBON_TRACE_LOGFILE.policies.time.modulate = true
+appender.CARBON_TRACE_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.CARBON_TRACE_LOGFILE.policies.size.size = 10MB
+appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.CARBON_TRACE_LOGFILE.strategy.max = 20
+
+# Appender config FOR CARBON_TRACE_CONSOLE
+appender.CARBON_TRACE_CONSOLE.type = Console
+appender.CARBON_TRACE_CONSOLE.name = CARBON_TRACE_CONSOLE
+appender.CARBON_TRACE_CONSOLE.layout.type = PatternLayout
+appender.CARBON_TRACE_CONSOLE.layout.pattern = TRACE [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.CARBON_TRACE_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CARBON_TRACE_CONSOLE.filter.threshold.level = DEBUG
+
+# Appender config to put correlation Log.
+appender.CORRELATION.type = RollingFile
+appender.CORRELATION.name = CORRELATION
+appender.CORRELATION.fileName = ${sys:carbon.home}/repository/logs/correlation.log
+appender.CORRELATION.filePattern =${sys:carbon.home}/repository/logs/correlation-%d{MM-dd-yyyy}-%i.log.gz
+appender.CORRELATION.layout.type = PatternLayout
+appender.CORRELATION.layout.pattern = %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION.policies.type = Policies
+appender.CORRELATION.policies.time.type = TimeBasedTriggeringPolicy
+appender.CORRELATION.policies.time.interval = 1
+appender.CORRELATION.policies.time.modulate = true
+appender.CORRELATION.policies.size.type = SizeBasedTriggeringPolicy
+appender.CORRELATION.policies.size.size = 10MB
+appender.CORRELATION.strategy.type = DefaultRolloverStrategy
+appender.CORRELATION.strategy.max = 20
+appender.CORRELATION.filter.threshold.type = ThresholdFilter
+appender.CORRELATION.filter.threshold.level = INFO
+
+# Appender config FOR CORRELATION_CONSOLE
+appender.CORRELATION_CONSOLE.type = Console
+appender.CORRELATION_CONSOLE.name = CORRELATION_CONSOLE
+appender.CORRELATION_CONSOLE.layout.type = PatternLayout
+appender.CORRELATION_CONSOLE.layout.pattern = CREL %d{yyyy-MM-dd HH:mm:ss,SSS}|%X{Correlation-ID}|%t|%m%n
+appender.CORRELATION_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.CORRELATION_CONSOLE.filter.threshold.level = INFO
+
+appender.ERROR_LOGFILE.type = RollingFile
+appender.ERROR_LOGFILE.name = ERROR_LOGFILE
+appender.ERROR_LOGFILE.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-errors.log
+appender.ERROR_LOGFILE.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-errors-%d{MM-dd-yyyy}-%i.log.gz
+appender.ERROR_LOGFILE.layout.type = PatternLayout
+appender.ERROR_LOGFILE.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.ERROR_LOGFILE.policies.type = Policies
+appender.ERROR_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.time.interval = 1
+appender.ERROR_LOGFILE.policies.time.modulate = true
+appender.ERROR_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.ERROR_LOGFILE.policies.size.size = 10MB
+appender.ERROR_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.ERROR_LOGFILE.strategy.max = 20
+appender.ERROR_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.ERROR_LOGFILE.filter.threshold.level = WARN
+
+appender.CARBON_SYS_LOG.type = Syslog
+appender.CARBON_SYS_LOG.name = CARBON_SYS_LOG
+appender.CARBON_SYS_LOG.host = localhost
+appender.CARBON_SYS_LOG.facility = USER
+appender.CARBON_SYS_LOG.layout.type = PatternLayout
+appender.CARBON_SYS_LOG.layout.pattern = [%d] %5p - %x %m {%c}%n
+appender.CARBON_SYS_LOG.filter.threshold.type = ThresholdFilter
+appender.CARBON_SYS_LOG.filter.threshold.level = DEBUG
+
+appender.OPEN_TRACING.type = RollingFile
+appender.OPEN_TRACING.name = OPEN_TRACING
+appender.OPEN_TRACING.fileName = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing.log
+appender.OPEN_TRACING.filePattern = ${sys:carbon.home}/repository/logs/wso2-apimgt-open-tracing-%d{MM-dd-yyyy}-%i.log.gz
+appender.OPEN_TRACING.layout.type = PatternLayout
+appender.OPEN_TRACING.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %m%nn
+appender.OPEN_TRACING.policies.type = Policies
+appender.OPEN_TRACING.policies.time.type = TimeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.time.interval = 1
+appender.OPEN_TRACING.policies.time.modulate = true
+appender.OPEN_TRACING.policies.size.type = SizeBasedTriggeringPolicy
+appender.OPEN_TRACING.policies.size.size = 10MB
+appender.OPEN_TRACING.strategy.type = DefaultRolloverStrategy
+appender.OPEN_TRACING.strategy.max = 20
+appender.OPEN_TRACING.filter.threshold.type = ThresholdFilter
+appender.OPEN_TRACING.filter.threshold.level = TRACE
+
+appender.TRACE_APPENDER.type = RollingFile
+appender.TRACE_APPENDER.name = TRACE_APPENDER
+appender.TRACE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-trace.log
+appender.TRACE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-trace-%d{MM-dd-yyyy}.log
+appender.TRACE_APPENDER.layout.type = PatternLayout
+appender.TRACE_APPENDER.layout.pattern = %d{HH:mm:ss,SSS} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.TRACE_APPENDER.policies.type = Policies
+appender.TRACE_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.TRACE_APPENDER.policies.time.interval = 1
+appender.TRACE_APPENDER.policies.time.modulate = true
+appender.TRACE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.TRACE_APPENDER.strategy.max = 20
+
+appender.SERVICE_APPENDER.type = RollingFile
+appender.SERVICE_APPENDER.name = SERVICE_APPENDER
+appender.SERVICE_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-apigw-service.log
+appender.SERVICE_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-apigw-service-%i.log
+appender.SERVICE_APPENDER.layout.type = PatternLayout
+appender.SERVICE_APPENDER.layout.pattern = %d{ISO8601} [%X{ip}-%X{host}] [%t] %5p %c{1} %m%n
+appender.SERVICE_APPENDER.policies.type = Policies
+appender.SERVICE_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.SERVICE_APPENDER.policies.size.size=1000KB
+appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.SERVICE_APPENDER.strategy.max = 10
+
+appender.HTTP_ACCESS.type = RollingFile
+appender.HTTP_ACCESS.name = HTTP_ACCESS
+appender.HTTP_ACCESS.fileName =${sys:carbon.home}/repository/logs/wso2carbon.log
+appender.HTTP_ACCESS.filePattern =${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}.log
+appender.HTTP_ACCESS.layout.type = PatternLayout
+appender.HTTP_ACCESS.layout.pattern = [%X{Correlation-ID}] %mm%n
+appender.HTTP_ACCESS.policies.type = Policies
+appender.HTTP_ACCESS.policies.time.type = TimeBasedTriggeringPolicy
+appender.HTTP_ACCESS.policies.time.interval = 1
+appender.HTTP_ACCESS.policies.time.modulate = true
+appender.HTTP_ACCESS.policies.size.type = SizeBasedTriggeringPolicy
+appender.HTTP_ACCESS.policies.size.size=10MB
+appender.HTTP_ACCESS.strategy.type = DefaultRolloverStrategy
+appender.HTTP_ACCESS.strategy.max = 20
+appender.HTTP_ACCESS.filter.threshold.type = ThresholdFilter
+appender.HTTP_ACCESS.filter.threshold.level = INFO
+
+# Appender config for Http access console
+appender.HTTP_ACCESS_CONSOLE.type = Console
+appender.HTTP_ACCESS_CONSOLE.name = HTTP_ACCESS_CONSOLE
+appender.HTTP_ACCESS_CONSOLE.layout.type = PatternLayout
+# appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP %msg%n
+appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP [%X{Correlation-ID}] %mm%n
+appender.HTTP_ACCESS_CONSOLE.filter.threshold.type = ThresholdFilter
+appender.HTTP_ACCESS_CONSOLE.filter.threshold.level = DEBUG
+
+appender.osgi.type = PaxOsgi
+appender.osgi.name = PaxOsgi
+appender.osgi.filter = *
+
+loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG, HTTP_ACCESS, synapse-wire
+
+logger.API_LOG.name = API_LOG
+logger.API_LOG.level = INFO
+logger.API_LOG.appenderRef.API_LOGFILE.ref = API_LOGFILE
+logger.API_LOG.additivity = false
+
+
+logger.AUDIT_LOG.name = AUDIT_LOG
+logger.AUDIT_LOG.level = INFO
+logger.AUDIT_LOG.appenderRef.AUDIT_LOGFILE.ref = AUDIT_LOGFILE
+logger.AUDIT_LOG.appenderRef.AUDIT_CONSOLE.ref = AUDIT_CONSOLE
+logger.AUDIT_LOG.additivity = false
+
+logger.trace-messages.name = trace.messages
+logger.trace-messages.level = TRACE
+logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
+logger.trace-messages.appenderRef.CARBON_TRACE_CONSOLE.ref = CARBON_TRACE_CONSOLE
+
+logger.HTTP_ACCESS.name = HTTP_ACCESS
+logger.HTTP_ACCESS.level = INFO
+logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS.ref = HTTP_ACCESS
+logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS_CONSOLE.ref = HTTP_ACCESS_CONSOLE
+logger.HTTP_ACCESS.additivity = false
+
+logger.org-apache-coyote.name = org.apache.coyote
+logger.org-apache-coyote.level = WARN
+
+logger.com-hazelcast.name = com.hazelcast
+logger.com-hazelcast.level = ERROR
+
+logger.Owasp-CsrfGuard.name = Owasp.CsrfGuard
+logger.Owasp-CsrfGuard.level = WARN
+
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
+logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
+logger.org-apache-axis2-clustering.level = INFO
+logger.org-apache-axis2-clustering.additivity = false
+
+logger.org-apache.name = org.apache
+logger.org-apache.level = INFO
+logger.org-apache.additivity = false
+logger.org-apache.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-catalina.name = org.apache.catalina
+logger.org-apache-catalina.level = ERROR
+
+logger.org-apache-tomcat.name = org.apache.tomcat
+logger.org-apache-tomcat.level = INFO
+
+logger.org-wso2-carbon-apacheds.name = org.wso2.carbon.apacheds
+logger.org-wso2-carbon-apacheds.level = WARN
+
+logger.org-apache-directory-server-ldap.name = org.apache.directory.server.ldap
+logger.org-apache-directory-server-ldap.level = ERROR
+
+logger.org-apache-directory-server-core-event.name = org.apache.directory.server.core.event
+logger.org-apache-directory-server-core-event.level = WARN
+
+logger.com-atomikos.name = com.atomikos
+logger.com-atomikos.level = INFO
+logger.com-atomikos.additivity = false
+logger.com-atomikos.appenderRef.ATOMIKOS_LOGFILE.ref = ATOMIKOS_LOGFILE
+
+logger.org-quartz.name = org.quartz
+logger.org-quartz.level = WARN
+
+logger.org-apache-jackrabbit-webdav.name = org.apache.jackrabbit.webdav
+logger.org-apache-jackrabbit-webdav.level = WARN
+
+logger.org-apache-juddi.name = org.apache.juddi
+logger.org-apache-juddi.level = ERROR
+
+logger.org-apache-commons-digester-Digester.name = org.apache.commons.digester.Digester
+logger.org-apache-commons-digester-Digester.level = WARN
+
+logger.org-apache-jasper-compiler-TldLocationsCache.name = org.apache.jasper.compiler.TldLocationsCache
+logger.org-apache-jasper-compiler-TldLocationsCache.level = WARN
+
+logger.org-apache-qpid.name = org.apache.qpid
+logger.org-apache-qpid.level = WARN
+
+logger.org-apache-qpid-server-Main.name = org.apache.qpid.server.Main
+logger.org-apache-qpid-server-Main.level = INFO
+
+logger.qpid-message.name = qpid.message
+logger.qpid-message.level = WARN
+
+logger.qpid-message-broker-listening.name = qpid.message.broker.listening
+logger.qpid-message-broker-listening.level = INFO
+
+logger.org-apache-tiles.name = org.apache.tiles
+logger.org-apache-tiles.level = WARN
+
+logger.org-apache-commons-httpclient.name = org.apache.commons.httpclient
+logger.org-apache-commons-httpclient.level = ERROR
+
+logger.org-apache-solr.name = org.apache.solr
+logger.org-apache-solr.level = ERROR
+
+logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassandra.hector.TimingLogger
+logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
+
+logger.org-wso2.name = org.wso2
+logger.org-wso2.level = INFO
+
+logger.org-wso2-carbon.name = org.wso2.carbon
+logger.org-wso2-carbon.level = INFO
+
+logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
+logger.org-apache-axis-enterprise.level = FATAL
+logger.org-apache-axis-enterprise.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
+logger.org-apache-directory-shared-ldap.level = WARN
+logger.org-apache-directory-shared-ldap.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
+logger.org-apache-directory-server-ldap-handlers.level = WARN
+logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+# Following are to remove false error messages from startup (IS)
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
+logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
+logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
+logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
+logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
+logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-server-core.name = org.apache.directory.server.core
+logger.org-apache-directory-server-core.level = ERROR
+logger.org-apache-directory-server-core.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
+logger.org-apache-directory-server-ldap-LdapSession.level = Error
+logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_CONSOLE.ref=CARBON_CONSOLE
+
+logger.correlation.name = correlation
+logger.correlation.level = INFO
+logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
+logger.correlation.appenderRef.CORRELATION_CONSOLE.ref = CORRELATION_CONSOLE
+logger.correlation.additivity = false
+
+# Hive Related Log configurations
+logger.DataNucleus.name = DataNucleus
+logger.DataNucleus.level = ERROR
+
+logger.Datastore.name = Datastore
+logger.Datastore.level = ERROR
+
+logger.Datastore-Schema.name = Datastore.Schema
+logger.Datastore-Schema.level = ERROR
+
+logger.JPOX-Datastore.name = JPOX.Datastore
+logger.JPOX-Datastore.level = ERROR
+
+logger.JPOX-Plugin.name = JPOX.Plugin
+logger.JPOX-Plugin.level = ERROR
+
+logger.JPOX-MetaData.name = JPOX.MetaData
+logger.JPOX-MetaData.level = ERROR
+
+logger.JPOX-Query.name = JPOX.Query
+logger.JPOX-Query.level = ERROR
+
+logger.JPOX-General.name = JPOX.General
+logger.JPOX-General.level = ERROR
+
+logger.JPOX-Enhancer.name = JPOX.Enhancer
+logger.JPOX-Enhancer.level = ERROR
+
+logger.org-apache-hadoop-hive.name = org.apache.hadoop.hive
+logger.org-apache-hadoop-hive.level = WARN
+
+logger.hive.name = hive
+logger.hive.level = WARN
+
+logger.ExecMapper.name = ExecMapper
+logger.ExecMapper.level = WARN
+
+logger.ExecReducer.name = ExecReducer
+logger.ExecReducer.level = WARN
+
+logger.net-sf-ehcache-config-ConfigurationFactory.name = net.sf.ehcache.config.ConfigurationFactory
+logger.net-sf-ehcache-config-ConfigurationFactory.level = ERROR
+
+logger.axis2Deployment.name = org.apache.axis2.deployment
+logger.axis2Deployment.level = WARN
+
+logger.equinox.name = org.eclipse.equinox
+logger.equinox.level = FATAL
+
+logger.tomcat2.name = tomcat
+logger.tomcat2.level = FATAL
+
+logger.StAXDialectDetector.name = org.apache.axiom.util.stax.dialect.StAXDialectDetector
+logger.StAXDialectDetector.level = ERROR
+
+logger.trace.name = tracer
+logger.trace.level = TRACE
+logger.trace.appenderRef.OPEN_TRACING.ref = OPEN_TRACING
+
+logger.synapse.name = org.apache.synapse
+logger.synapse.level = INFO
+
+logger.synapse_transport.name = org.apache.synapse.transport
+logger.synapse_transport.level = INFO
+
+logger.axis2.name = org.apache.axis2
+logger.axis2.level = INFO
+
+logger.axis2_transport.name = org.apache.axis2.transport
+logger.axis2_transport.level = INFO
+
+logger.hunsicker.name = de.hunsicker.jalopy.io
+logger.hunsicker.level = FATAL
+
+logger.synapse-headers.name = org.apache.synapse.transport.http.headers
+logger.synapse-headers.level = DEBUG
+
+logger.synapse-wire.name = org.apache.synapse.transport.http.wire
+logger.synapse-wire.level = DEBUG
+
+logger.thrift-publisher.name = org.wso2.carbon.databridge.agent.thrift.AsyncDataPublisher
+logger.thrift-publisher.level = WARN
+
+logger.service_logger.name = SERVICE_LOGGER
+logger.service_logger.level = INFO
+logger.service_logger.additivity = false
+logger.service_logger.appenderRef.SERVICE_APPENDER.ref = SERVICE_APPENDER
+
+logger.wso2-callhome.name = org.wso2.callhome
+logger.wso2-callhome.level = INFO
+
+logger.trace_logger.name = TRACE_LOGGER
+logger.trace_logger.level = INFO
+logger.trace_logger.appenderRef.TRACE_APPENDER.ref = TRACE_APPENDER
+
+# root loggers
+rootLogger.level = ERROR
+rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
+rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+rootLogger.appenderRef.ERROR_LOGFILE.ref = ERROR_LOGFILE
+rootLogger.appenderRef.PaxOsgi.ref = PaxOsgi
+#rootLogger.appenderReg.CARBON_SYS_LOG.ref = CARBON_SYS_LOG
+#rootLogger.appenderRef.syslog.ref = syslog
+
+# bot detection feature appender
+appender.BOTDATA_APPENDER.type = RollingFile
+appender.BOTDATA_APPENDER.name = BOTDATA_APPENDER
+appender.BOTDATA_APPENDER.fileName = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData.log
+appender.BOTDATA_APPENDER.filePattern = ${sys:carbon.home}/repository/logs/wso2-BotDetectedData-%d{MM-dd-yyyy}.log
+appender.BOTDATA_APPENDER.layout.type = PatternLayout
+appender.BOTDATA_APPENDER.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
+appender.BOTDATA_APPENDER.policies.type = Policies
+appender.BOTDATA_APPENDER.policies.time.type = TimeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.time.interval = 1
+appender.BOTDATA_APPENDER.policies.time.modulate = true
+appender.BOTDATA_APPENDER.policies.size.type = SizeBasedTriggeringPolicy
+appender.BOTDATA_APPENDER.policies.size.size = 10MB
+appender.BOTDATA_APPENDER.strategy.type = DefaultRolloverStrategy
+appender.BOTDATA_APPENDER.strategy.max = 20
+
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.name = org.wso2.carbon.apimgt.gateway.mediators.BotDetectionMediator
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.level = INFO
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.appenderRef.BOTDATA_APPENDER.ref = BOTDATA_APPENDER
+logger.org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator.additivity = false
+
+category.SERVICE_APPENDER._OpenService_ = TRACE_APPENDER, BOTDATA_APPENDER

--- a/samples/deployment/apim/all-in-one/confs/secret-conf.properties
+++ b/samples/deployment/apim/all-in-one/confs/secret-conf.properties
@@ -1,0 +1,12 @@
+keystore.identity.location=/home/wso2carbon/wso2am-{{ .Values.wso2.apim.version }}/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
+keystore.identity.type=JKS
+keystore.identity.store.password=identity.store.password
+keystore.identity.store.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
+secretRepositories.file.provider=org.wso2.securevault.secret.repository.FileBaseSecretRepositoryProvider
+secretRepositories.file.location=repository/conf/security/cipher-text.properties
+secretRepositories=file
+secVault.enabled=true
+keystore.identity.key.password=identity.key.password
+carbon.secretProvider=org.wso2.securevault.secret.handler.SecretManagerSecretCallbackHandler
+keystore.identity.key.secretProvider=org.wso2.carbon.securevault.DefaultSecretCallbackHandler
+keystore.identity.alias={{ .Values.wso2.apim.configurations.security.keystores.internal.alias }}

--- a/samples/deployment/apim/all-in-one/templates/NOTES.txt
+++ b/samples/deployment/apim/all-in-one/templates/NOTES.txt
@@ -1,0 +1,41 @@
+Thank you for installing WSO2 API Manager.
+
+Please follow these steps to access API Manager Publisher, DevPortal consoles.
+
+1. Obtain the external IP (`EXTERNAL-IP`) of the API Manager Ingress resources, by listing down the Kubernetes Ingresses.
+
+  kubectl get ing -n {{ .Release.Namespace }}
+
+  The output under the relevant column stands for the following.
+
+  API Manager Publisher-DevPortal
+
+  - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-all-in-one.fullname" . }}-am-ingress)
+  - HOSTS: Hostname of the WSO2 API Manager service ({{ .Values.kubernetes.ingress.management.hostname }})
+  - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager service to outside of the Kubernetes environment
+  - PORTS: Externally exposed service ports of the API Manager service
+
+  API Manager Gateway
+
+  - NAME: Metadata name of the Kubernetes Ingress resource (defaults to {{ template "am-all-in-one.fullname" . }}-am-gateway-ingress)
+  - HOSTS: Hostname of the WSO2 API Manager's Gateway service ({{ .Values.kubernetes.ingress.gateway.hostname }})
+  - ADDRESS: External IP (`EXTERNAL-IP`) exposing the API Manager's Gateway service to outside of the Kubernetes environment
+  - PORTS: Externally exposed service ports of the API Manager' Gateway service
+
+
+2. Add a DNS record mapping the hostnames (in step 1) and the external IP.
+
+   If the defined hostnames (in step 1) are backed by a DNS service, add a DNS record mapping the hostnames and
+   the external IP (`EXTERNAL-IP`) in the relevant DNS service.
+
+   If the defined hostnames are not backed by a DNS service, for the purpose of evaluation you may add an entry mapping the
+   hostnames and the external IP in the `/etc/hosts` file at the client-side.
+
+   <EXTERNAL-IP> {{ .Values.kubernetes.ingress.management.hostname }} {{ .Values.kubernetes.ingress.gateway.hostname }}
+
+3. Navigate to the consoles in your browser of choice.
+
+   API Manager Publisher: https://{{ .Values.kubernetes.ingress.management.hostname }}/publisher
+   API Manager DevPortal: https://{{ .Values.kubernetes.ingress.management.hostname }}/devportal
+
+Please refer the official documentation at https://apim.docs.wso2.com/en/latest/ for additional information on WSO2 API Manager.

--- a/samples/deployment/apim/all-in-one/templates/_helpers.tpl
+++ b/samples/deployment/apim/all-in-one/templates/_helpers.tpl
@@ -1,0 +1,82 @@
+{{/*
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------s
+*/}}
+
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "am-all-in-one.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "am-all-in-one.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "am-all-in-one.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "am-all-in-one.labels" -}}
+app.kubernetes.io/name: {{ include "am-all-in-one.name" . }}
+helm.sh/chart: {{ include "am-all-in-one.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{/*
+Common prefix prepended to Kubernetes resources of this chart
+*/}}
+{{- define "am-all-in-one.resource.prefix" -}}
+{{- "wso2am-all-in-one" }}
+{{- end -}}
+
+{{- define "image" }}
+{{- $imageName := .deployment.imageName }}
+{{- $imageTag := .deployment.imageTag | default "" }}
+{{- if or (eq .Values.wso2.subscription.username "") (eq .Values.wso2.subscription.password "") -}}
+{{- $dockerRegistry := .deployment.dockerRegistry | default "wso2" }}
+image: {{ $dockerRegistry }}/{{ $imageName }}{{- if not (eq $imageTag "") }}{{- printf ":%s" $imageTag -}}{{- end }}
+{{- else }}
+{{- $dockerRegistry := .deployment.dockerRegistry | default "docker.wso2.com" }}
+{{- $parts := len (split "." $imageTag) }}
+{{- if eq $parts 3 }}
+image: {{ $dockerRegistry }}/{{ $imageName }}{{- if not (eq $imageTag "") }}:{{ $imageTag }}.0{{- end }}
+{{- else }}
+image: {{ $dockerRegistry }}/{{ $imageName }}{{- if not (eq $imageTag "") }}:{{ $imageTag }}{{- end }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-entrypoint.yaml
@@ -1,0 +1,56 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-entrypoint
+  namespace: {{ .Release.Namespace }}
+data:
+  docker-entrypoint.sh: |
+    #!/bin/bash
+    set -e
+
+    # volume mounts
+    config_volume=${WORKING_DIRECTORY}/wso2-config-volume
+    artifact_volume=${WORKING_DIRECTORY}/wso2-artifact-volume
+
+    # check if the WSO2 non-root user home exists
+    test ! -d ${WORKING_DIRECTORY} && echo "WSO2 Docker non-root user home does not exist" && exit 1
+
+    # check if the WSO2 product home exists
+    test ! -d ${WSO2_SERVER_HOME} && echo "WSO2 Docker product home does not exist" && exit 1
+
+    # Copying carbon_db
+    if ! test -f /home/wso2carbon/solr/database/WSO2CARBON_DB.mv.db
+    then
+      echo "Copying WSO2CARBON_DB.mv.db" >&2
+      cp ${WSO2_SERVER_HOME}/repository/database/WSO2CARBON_DB.mv.db /home/wso2carbon/solr/database/
+    fi
+
+    # copy any configuration changes mounted to config_volume
+    test -d ${config_volume} && [[ "$(ls -A ${config_volume})" ]] && cp -RL ${config_volume}/* ${WSO2_SERVER_HOME}/
+    # copy any artifact changes mounted to artifact_volume
+    test -d ${artifact_volume} && [[ "$(ls -A ${artifact_volume})" ]] && cp -RL ${artifact_volume}/* ${WSO2_SERVER_HOME}/
+
+    {{- if .Values.wso2.apim.secureVaultEnabled }}
+    # copy internal keystore credentials to password-tmp file for cipher-tool usage
+    {{- if .Values.azure.enabled }}
+    cp /mnt/secrets-store/{{ .Values.azure.keyVault.secretIdentifiers.internalKeystorePassword }} ${WSO2_SERVER_HOME}/password-tmp
+    {{- else if .Values.aws.enabled }}
+    cp /mnt/secrets-store/{{ .Values.aws.secretsManager.secretIdentifiers.internalKeystorePassword.secretKey }} ${WSO2_SERVER_HOME}/password-tmp
+    {{- else if .Values.gcp.enabled }}
+    cp /mnt/secrets-store/{{ .Values.gcp.secretsManager.secret.secretName }} ${WSO2_SERVER_HOME}/password-tmp
+    {{- end }}
+    {{- end }}
+
+    # start WSO2 Carbon server
+    sh ${WSO2_SERVER_HOME}/bin/api-manager.sh "$@" {{ .Values.wso2.apim.startupArgs }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-log4j2.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-log4j2.yaml
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-log4j2
+  namespace : {{ .Release.Namespace }}
+data:
+  log4j2.properties: {{ tpl (.Files.Get "confs/log4j2.properties") . | quote }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-script.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-script.yaml
@@ -1,0 +1,19 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+{{- if .Values.wso2.apim.mountStartupScript }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-sh
+  namespace : {{ .Release.Namespace }}
+data:
+  api-manager.sh: {{ tpl (.Files.Get "confs/api-manager.sh") . | quote}}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-secret-conf.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-conf-secret-conf.yaml
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.wso2.apim.secureVaultEnabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-conf-secret-conf
+  namespace : {{ .Release.Namespace }}
+data:
+  secret-conf.properties: {{ tpl (.Files.Get "confs/secret-conf.properties") . | quote}}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-conf.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-conf.yaml
@@ -1,0 +1,18 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-conf
+  namespace : {{ .Release.Namespace }}
+data:
+  deployment.toml: {{ tpl (.Files.Get "confs/deployment.toml") . | quote }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-deployment.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-deployment.yaml
@@ -1,0 +1,245 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-deployment
+  namespace: {{ .Release.Namespace }}
+  labels:
+    component: wso2apim
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      deployment: {{ template "am-all-in-one.fullname" . }}-am
+      node: {{ template "am-all-in-one.fullname" . }}-am
+  template:
+    metadata:
+      annotations:
+        checksum.am.conf: {{ include (print $.Template.BasePath "/am/wso2am-conf.yaml") . | sha256sum }}
+        checksum.am.conf.log4j2: {{ include (print $.Template.BasePath "/am/wso2am-conf-log4j2.yaml") . | sha256sum }}
+        checksum.am.conf.secret-conf: {{ include (print $.Template.BasePath "/am/wso2am-conf-secret-conf.yaml") . | sha256sum }}
+      labels:
+        deployment: {{ template "am-all-in-one.fullname" . }}-am
+        node: {{ template "am-all-in-one.fullname" . }}-am
+        product: apim
+        component: wso2apim
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deployment
+                  operator: In
+                  values:
+                  - {{ template "am-all-in-one.fullname" . }}
+              topologyKey: "topology.kubernetes.io/zone"
+            weight: 100
+      {{- if .Values.wso2.apim.secureVaultEnabled }} 
+      {{- if .Values.aws.enabled }}
+      serviceAccount: {{ .Values.aws.serviceAccountName }}
+      {{- else if .Values.gcp.enabled }}
+      serviceAccount: {{ .Values.gcp.serviceAccountName }}
+      {{- else if .Values.azure.enabled }}
+      serviceAccount: {{ .Values.azure.serviceAccountName }}
+      {{- end }}
+      {{- end }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: wso2am
+          image: {{ .Values.wso2.deployment.image.registry }}/{{ .Values.wso2.deployment.image.repository }}@{{ .Values.wso2.deployment.image.digest }}
+          imagePullPolicy: {{ .Values.wso2.deployment.imagePullPolicy }}
+          env:
+            - name: NODE_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: JVM_MEM_OPTS
+              value: "-Xms{{ .Values.wso2.deployment.resources.jvm.memory.xms }} -Xmx{{ .Values.wso2.deployment.resources.jvm.memory.xmx }}"
+          startupProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - nc -z localhost 9443
+            initialDelaySeconds: {{ .Values.wso2.deployment.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.wso2.deployment.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.wso2.deployment.startupProbe.failureThreshold }}         
+          livenessProbe:
+            httpGet:
+              path: /services/Version
+              port: 9763
+            initialDelaySeconds: {{ .Values.wso2.deployment.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.wso2.deployment.livenessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.wso2.deployment.livenessProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /api/am/gateway/v2/server-startup-healthcheck
+              port: 9443
+              scheme: HTTPS
+            initialDelaySeconds: {{ .Values.wso2.deployment.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.wso2.deployment.readinessProbe.periodSeconds }}
+            failureThreshold: {{ .Values.wso2.deployment.readinessProbe.failureThreshold }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - "sh"
+                  - "-c"
+                  - >
+                    echo "Pre stop hook triggered";
+                    sleep {{ .Values.wso2.deployment.lifecycle.preStopHook.sleepSeconds }}; 
+                    echo "Shutdown APIM Server";
+                    ${WSO2_SERVER_HOME}/bin/api-manager.sh stop
+          resources:
+            requests:
+              memory: {{ .Values.wso2.deployment.resources.requests.memory }}
+              cpu: {{ .Values.wso2.deployment.resources.requests.cpu }}
+            limits:
+              memory: {{ .Values.wso2.deployment.resources.limits.memory }}
+              cpu: {{ .Values.wso2.deployment.resources.limits.cpu }}
+          securityContext:
+            runAsUser: {{ .Values.kubernetes.securityContext.runAsUser }}
+            runAsGroup: {{ .Values.kubernetes.securityContext.runAsGroup }}
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - all
+          ports:
+            - containerPort: 8280
+              protocol: "TCP"
+            - containerPort: 8243
+              protocol: "TCP"
+            - containerPort: 9763
+              protocol: "TCP"
+            - containerPort: 9443
+              protocol: "TCP"
+            - containerPort: 9711
+              protocol: "TCP"
+            - containerPort: 9611
+              protocol: "TCP"
+            - containerPort: 5672
+              protocol: "TCP"
+          volumeMounts:
+            - name: wso2am-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/deployment.toml
+              subPath: deployment.toml
+            - name: wso2am-entrypoint
+              mountPath: /home/wso2carbon/docker-entrypoint.sh
+              subPath: docker-entrypoint.sh
+            - name: wso2am-log4j2
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/log4j2.properties
+              subPath: log4j2.properties
+            {{- if .Values.wso2.apim.mountStartupScript }}
+            - name: wso2am-sh-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/bin/api-manager.sh
+              subPath: api-manager.sh
+            {{- end }}
+            {{- if .Values.wso2.apim.secureVaultEnabled }}
+            - name: wso2am-secret-conf
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/conf/security/secret-conf.properties
+              subPath: secret-conf.properties
+            - name: wso2am-secret-store-csi
+              mountPath: /mnt/secrets-store
+              readOnly: true
+            {{- end }}
+            {{- if .Values.wso2.apim.configurations.security.jksSecretName }}
+            - name: wso2am-keystores
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.truststore.name }}
+              subPath: {{ .Values.wso2.apim.configurations.security.truststore.name }}
+            {{- if .Values.wso2.apim.configurations.security.keystores.primary.enabled }}
+            - name: wso2am-keystores
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.primary.name }}
+              subPath: {{ .Values.wso2.apim.configurations.security.keystores.primary.name }}
+            {{- end }}
+            {{- if .Values.wso2.apim.configurations.security.keystores.tls.enabled }}
+            - name: wso2am-keystores
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.tls.name }}
+              subPath: {{ .Values.wso2.apim.configurations.security.keystores.tls.name }}
+            {{- end }}
+            {{- if .Values.wso2.apim.configurations.security.keystores.internal.enabled }}
+            - name: wso2am-keystores
+              mountPath: /home/wso2carbon/wso2-config-volume/repository/resources/security/{{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
+              subPath: {{ .Values.wso2.apim.configurations.security.keystores.internal.name }}
+            {{- end }}
+            {{- end }}
+            {{ if .Values.wso2.deployment.persistence.solrIndexing.enabled }}
+            - name: wso2am-local-carbondb
+              mountPath: /home/wso2carbon/solr/database
+            - name: wso2am-solr
+              mountPath: /home/wso2carbon/solr/indexed-data
+            {{ end }}
+      {{- if .Values.wso2.deployment.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.wso2.deployment.nodeSelector | nindent 8 }}
+      {{- end }}
+      volumes:
+        - name: wso2am-conf
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-am-conf
+            defaultMode: 0407
+        - name: wso2am-entrypoint
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-entrypoint
+            defaultMode: 0407
+        - name: wso2am-log4j2
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-log4j2
+            defaultMode: 0407
+        {{- if .Values.wso2.apim.mountStartupScript }}
+        - name: wso2am-sh-conf
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-sh
+            defaultMode: 0407
+        {{- end }}
+        {{- if .Values.wso2.apim.secureVaultEnabled }}
+        - name: wso2am-secret-conf
+          configMap:
+            name: {{ template "am-all-in-one.fullname" . }}-conf-secret-conf
+            defaultMode: 0407
+        - name: wso2am-secret-store-csi
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            {{ if .Values.azure.enabled }}
+            volumeAttributes:
+              secretProviderClass: {{ .Values.azure.keyVault.secretProviderClass }}
+            nodePublishSecretRef:
+              name: {{ .Values.azure.keyVault.activeDirectory.servicePrincipal.credentialsSecretName }}
+            {{- else if .Values.aws.enabled }}
+            volumeAttributes:
+              secretProviderClass: {{ .Values.aws.secretsManager.secretProviderClass }}
+            {{- else if .Values.gcp.enabled }}
+            volumeAttributes:
+              secretProviderClass: {{ .Values.gcp.secretsManager.secretProviderClass }}
+            {{- end }}
+        {{- end }}
+        {{- if .Values.wso2.apim.configurations.security.jksSecretName }}
+        - name: wso2am-keystores
+          secret:
+            secretName: {{ .Values.wso2.apim.configurations.security.jksSecretName }}
+        {{- end }}
+        {{ if .Values.wso2.deployment.persistence.solrIndexing.enabled }}
+        - name: wso2am-local-carbondb
+          persistentVolumeClaim:
+            claimName: {{ template "am-all-in-one.fullname" . }}-am-local-carbon-database-volume-claim
+        - name: wso2am-solr
+          persistentVolumeClaim:
+            claimName: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
+        {{ end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-gateway-ingress.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-gateway-ingress.yaml
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.kubernetes.ingress.gateway.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-gateway-ingress
+  namespace : {{ .Release.Namespace }}
+{{- if .Values.kubernetes.ingress.gateway.annotations }}
+  annotations:
+{{ toYaml .Values.kubernetes.ingress.gateway.annotations | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.kubernetes.ingressClass }}
+  tls:
+  - hosts:
+    - {{ .Values.kubernetes.ingress.gateway.hostname }}
+  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+  rules:
+  - host: {{ .Values.kubernetes.ingress.gateway.hostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "am-all-in-one.fullname" . }}-am-service
+            port:
+              number: 8243
+{{- end -}}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-ingress.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-ingress.yaml
@@ -1,0 +1,39 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.kubernetes.ingress.management.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-ingress
+  namespace : {{ .Release.Namespace }}
+{{- if .Values.kubernetes.ingress.management.annotations }}
+  annotations:
+{{ toYaml .Values.kubernetes.ingress.management.annotations | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.kubernetes.ingressClass }}
+  tls:
+  - hosts:
+    - {{ .Values.kubernetes.ingress.management.hostname }}
+  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+  rules:
+  - host: {{ .Values.kubernetes.ingress.management.hostname }}
+    http:
+      paths:
+        - path: /
+          pathType: Prefix
+          backend:
+            service:
+              name: {{ template "am-all-in-one.fullname" . }}-am-service
+              port:
+                number: 9443
+{{- end -}}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-pdb.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-pdb.yaml
@@ -1,0 +1,20 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-pdb
+spec:
+  minAvailable: {{ .Values.wso2.deployment.minAvailable | quote }}
+  selector:
+    matchLabels:
+      deployment: {{ template "am-all-in-one.fullname" . }}-am

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-secret-store-provider-gcp.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-secret-store-provider-gcp.yaml
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if and .Values.wso2.apim.secureVaultEnabled .Values.gcp.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.gcp.secretsManager.secretProviderClass }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider: gcp
+  parameters:
+    secrets: |
+        - resourceName: "projects/{{ .Values.gcp.secretsManager.projectId }}/secrets/{{ .Values.gcp.secretsManager.secret.secretName }}/versions/{{ .Values.gcp.secretsManager.secret.secretVersion }}"
+          path: {{ .Values.gcp.secretsManager.secret.secretName }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-service.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-service.yaml
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-service
+  namespace : {{ .Release.Namespace }}
+spec:
+  # label keys and values that must match in order to receive traffic for this service
+  selector:
+    deployment: {{ template "am-all-in-one.fullname" . }}-am
+    node: {{ template "am-all-in-one.fullname" . }}-am
+  ports:
+    # ports that this service should serve on
+    - name: pass-through-http
+      protocol: TCP
+      port: 8280
+    - name: pass-through-https
+      protocol: TCP
+      port: 8243
+    - name: binary
+      protocol: TCP
+      port: 9611
+    - name: binary-secure
+      protocol: TCP
+      port: 9711
+    - name: jms-tcp
+      protocol: TCP
+      port: 5672
+    - name: servlet-https
+      protocol: TCP
+      port: 9443
+    - name: websub-http
+      protocol: TCP
+      port: 9021
+    - name: websub-https
+      protocol: TCP
+      port: 8021

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-storageclass-gcp.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-storageclass-gcp.yaml
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.gcp.enabled }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-sc
+provisioner: filestore.csi.storage.gke.io
+parameters:
+  tier: {{ .Values.gcp.fs.tier | quote }}
+  network: {{ .Values.gcp.fs.network | quote }}
+  uid: {{ .Values.kubernetes.securityContext.runAsUser | quote }}
+  gid: {{ .Values.kubernetes.securityContext.runAsUser | quote }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-storageclass.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-storageclass.yaml
@@ -1,0 +1,24 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.aws.enabled }}
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-sc
+provisioner: efs.csi.aws.com
+parameters:
+  provisioningMode: efs-ap
+  fileSystemId: {{ .Values.aws.efs.fileSystemId | quote }}
+  directoryPerms: {{ .Values.aws.efs.directoryPerms | quote }}
+  uid: {{ .Values.kubernetes.securityContext.runAsUser | quote }}
+  gid: {{ .Values.kubernetes.securityContext.runAsUser | quote }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-aws.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-aws.yaml
@@ -1,0 +1,51 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.aws.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-local-carbon-database
+  labels:
+    purpose: am-carbondb
+spec:
+  capacity:
+    storage: {{ .Values.aws.efs.capacity }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ .Values.aws.efs.fileSystemId }}::{{ .Values.aws.efs.accessPoints.carbonDb }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-solr-indexed-data
+  labels:
+    purpose: am-solr
+spec:
+  capacity:
+    storage: {{ .Values.aws.efs.capacity }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: efs.csi.aws.com
+    volumeHandle: {{ .Values.aws.efs.fileSystemId }}::{{ .Values.aws.efs.accessPoints.solr }}
+
+{{ end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-azure.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-azure.yaml
@@ -1,0 +1,37 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.azure.enabled }}
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}
+  labels:
+    purpose: am-volume
+spec:
+  accessModes:
+    - ReadWriteMany
+  capacity:
+    storage: {{ .Values.azure.persistence.capacity }}
+  persistentVolumeReclaimPolicy: Retain
+  volumeMode: Filesystem
+  azureFile:
+    secretName: {{ .Values.azure.persistence.secretName }}
+    secretNamespace: {{ .Release.Namespace }}
+    shareName: {{ .Values.azure.persistence.fileShare }}
+  mountOptions:
+    - dir_mode=0777
+    - file_mode=0777
+    - uid=10001
+    - gid=10001
+    - cache=strict
+
+{{ end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-aws.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-aws.yaml
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.aws.enabled }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-local-carbon-database-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.carbonDatabase }}
+  selector:
+    matchLabels:
+      purpose: am-carbondb
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData }}
+  selector:
+    matchLabels:
+      purpose: am-solr
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-azure.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-azure.yaml
@@ -1,0 +1,47 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.azure.enabled }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-local-carbon-database-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.carbonDatabase }}
+  storageClassName: {{ .Values.azure.persistence.storageClass | default "" }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData }}
+  selector:
+    matchLabels:
+      purpose: am-volume
+  storageClassName: {{ .Values.azure.persistence.storageClass | default "" }}
+
+{{ end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-gcp.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-claims-gcp.yaml
@@ -1,0 +1,50 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.gcp.enabled }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-local-carbon-database-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.carbonDatabase }}
+  selector:
+    matchLabels:
+      purpose: am-carbondb
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+
+---
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-solr-indexed-data-volume-claim
+  namespace : {{ .Release.Namespace }}
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ .Values.wso2.deployment.persistence.solrIndexing.capacity.solrIndexedData }}
+  selector:
+    matchLabels:
+      purpose: am-solr
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-gcp.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-volume-gcp.yaml
@@ -1,0 +1,57 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{ if and .Values.wso2.deployment.persistence.solrIndexing.enabled .Values.gcp.enabled }}
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-local-carbon-database
+  labels:
+    purpose: am-carbondb
+spec:
+  capacity:
+    storage: {{ .Values.gcp.fs.capacity }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: filestore.csi.storage.gke.io
+    volumeHandle: "modeInstance/{{ .Values.gcp.fs.location }}/{{ .Values.gcp.fs.fileshares.carbonDB.fileStoreName }}/{{ .Values.gcp.fs.fileshares.carbonDB.fileShareName }}"
+    volumeAttributes:
+      ip: {{ .Values.gcp.fs.fileshares.carbonDB.ip }}
+      volume: {{ .Values.gcp.fs.fileshares.carbonDB.fileShareName }}
+
+---
+
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-solr-indexed-data
+  labels:
+    purpose: am-solr
+spec:
+  capacity:
+    storage: {{ .Values.gcp.fs.capacity }}
+  volumeMode: Filesystem
+  accessModes:
+    - ReadWriteMany
+  storageClassName: {{ template "am-all-in-one.fullname" . }}-sc
+  persistentVolumeReclaimPolicy: Retain
+  csi:
+    driver: filestore.csi.storage.gke.io
+    volumeHandle: "modeInstance/{{ .Values.gcp.fs.location }}/{{ .Values.gcp.fs.fileshares.solr.fileStoreName }}/{{ .Values.gcp.fs.fileshares.solr.fileShareName }}"
+    volumeAttributes:
+      ip: {{ .Values.gcp.fs.fileshares.solr.ip }}
+      volume: {{ .Values.gcp.fs.fileshares.solr.fileShareName }}
+
+{{ end }}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-websocket-ingress.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-websocket-ingress.yaml
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.kubernetes.ingress.websocket.enabled }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-websocket-ingress
+  namespace : {{ .Release.Namespace }}
+{{- if .Values.kubernetes.ingress.websocket.annotations }}
+  annotations:
+{{ toYaml .Values.kubernetes.ingress.websocket.annotations | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.kubernetes.ingressClass }}
+  tls:
+  - hosts:
+    - {{ .Values.kubernetes.ingress.websocket.hostname }}
+  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+  rules:
+  - host: {{ .Values.kubernetes.ingress.websocket.hostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "am-all-in-one.fullname" . }}-am-service
+            port:
+              number: 8099
+{{- end -}}

--- a/samples/deployment/apim/all-in-one/templates/am/wso2am-websub-ingress.yaml
+++ b/samples/deployment/apim/all-in-one/templates/am/wso2am-websub-ingress.yaml
@@ -1,0 +1,40 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if .Values.kubernetes.ingress.websub.enabled }}
+
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "am-all-in-one.fullname" . }}-am-websub-ingress
+  namespace : {{ .Release.Namespace }}
+{{- if .Values.kubernetes.ingress.websub.annotations }}
+  annotations:
+{{ toYaml .Values.kubernetes.ingress.websub.annotations | indent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ .Values.kubernetes.ingressClass }}
+  tls:
+  - hosts:
+    - {{ .Values.kubernetes.ingress.websub.hostname }}
+  secretName: {{ .Values.kubernetes.ingress.tlsSecret }}
+  rules:
+  - host: {{ .Values.kubernetes.ingress.websub.hostname }}
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ template "am-all-in-one.fullname" . }}-am-service
+            port:
+              number: 8021
+{{- end -}}

--- a/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-csi.yaml
+++ b/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-csi.yaml
@@ -1,0 +1,22 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if and .Values.wso2.apim.secureVaultEnabled .Values.azure.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:  
+  name: {{ template "am-all-in-one.fullname" . }}-secret-store-csi  
+  namespace: {{ .Release.Namespace }}
+type: Opaque
+data:  
+  clientid: {{ .Values.azure.keyVault.activeDirectory.servicePrincipal.appId | b64enc }}  
+  clientsecret: {{ .Values.azure.keyVault.activeDirectory.servicePrincipal.clientSecretName | b64enc }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-provider-aws.yaml
+++ b/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-provider-aws.yaml
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if and .Values.wso2.apim.secureVaultEnabled .Values.aws.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.aws.secretsManager.secretProviderClass }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider: aws
+  parameters:
+    region: {{ .Values.aws.region }}
+    objects: |
+        - objectName: {{ .Values.aws.secretsManager.secretIdentifiers.internalKeystorePassword.secretName | quote }}
+          objectType: "secretsmanager"
+          jmesPath:
+            - path: '{{ .Values.aws.secretsManager.secretIdentifiers.internalKeystorePassword.secretKey | quote }}'
+              objectAlias: {{ .Values.aws.secretsManager.secretIdentifiers.internalKeystorePassword.secretKey }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-provider-azure.yaml
+++ b/samples/deployment/apim/all-in-one/templates/secrets/wso2am-secret-store-provider-azure.yaml
@@ -1,0 +1,35 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2023, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained 
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the 
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+{{- if and .Values.wso2.apim.secureVaultEnabled .Values.azure.enabled }}
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: {{ .Values.azure.keyVault.secretProviderClass }}
+spec:
+  provider: azure
+  parameters:
+    keyvaultName: {{ .Values.azure.keyVault.name }}
+    userAssignedIdentityID: "{{ .Values.azure.keyVault.activeDirectory.servicePrincipal.appId }}"
+    objects: |
+      array:
+        - |
+          objectName: {{ .Values.azure.keyVault.secretIdentifiers.internalKeystorePassword }}
+          objectType: secret
+          objectVersion: ""
+        - |
+          objectName: {{ .Values.azure.keyVault.secretIdentifiers.internalKeystoreKeyPassword }}
+          objectType: secret
+          objectVersion: ""
+    tenantId: {{ .Values.azure.keyVault.activeDirectory.tenantId }}
+    resourceGroup: {{ .Values.azure.keyVault.resourceManager.resourceGroup }}
+    subscriptionId: {{ .Values.azure.keyVault.resourceManager.subscriptionId }}
+{{- end }}

--- a/samples/deployment/apim/all-in-one/values.yaml
+++ b/samples/deployment/apim/all-in-one/values.yaml
@@ -1,0 +1,635 @@
+# -------------------------------------------------------------------------------------
+#
+# Copyright (c) 2024, WSO2 LLC. (http://www.wso2.com). All Rights Reserved.
+#
+# This software is the property of WSO2 LLC. and its suppliers, if any.
+# Dissemination of any information or reproduction of any material contained
+# herein is strictly forbidden, unless permitted by WSO2 in accordance with the
+# WSO2 Commercial License available at https://wso2.com/licenses/eula/3.2
+#
+# --------------------------------------------------------------------------------------
+
+aws:
+  # -- If AWS is used as the cloud provider
+  enabled: false
+  efs:
+    # -- EFS capacity
+    capacity: ""
+    # -- EFS directory permissions
+    directoryPerms: "0777"
+    # -- EFS file system ID for mounting the persistent volume
+    fileSystemId: ""
+    # -- EFS Access Points for static provisioning
+    accessPoints:
+      carbonDb: ""
+      solr: ""
+  # -- AWS region
+  region: ""
+  secretsManager:
+    # -- AWS Secrets Manager secret provider class name
+    secretProviderClass: "wso2am-am-secret-provider-class"
+    secretIdentifiers:
+      # -- Internal keystore password identifier in secrets manager
+      internalKeystorePassword:
+        # -- AWS Secrets Manager secret name
+        secretName: ""
+        # -- AWS Secrets Manager secret key
+        secretKey: ""
+  # Name of Kubernetes service account
+  serviceAccountName: ""
+
+azure:
+  # -- If Azure is used as the cloud provider
+  enabled: false
+  keyVault:
+    # -- Azure Key vault used for credential management
+    name: ""
+    # -- Azure Key vault secret provider class name
+    secretProviderClass: "wso2am-secret-provider-class"
+    secretIdentifiers:
+      # -- Internal keystore password identifier in keyvault
+      internalKeystorePassword: ""
+      # -- Internal keystore key password identifier in keyvault
+      internalKeystoreKeyPassword: ""
+    activeDirectory:
+      # -- Service Principal created for transacting with the target Azure Key Vault
+      # For advanced details refer to official documentation (https://github.com/Azure/secrets-store-csi-driver-provider-azure/blob/master/docs/service-principal-mode.md)
+      servicePrincipal:
+        # -- Application ID of the service principal used in secret-store-csi
+        appId: ""
+        # -- Client secret name of the service principal used in secret-store-csi
+        clientSecretName: ""
+        # -- Credentials secret name of the service principal used as nodePublisherRef
+        credentialsSecretName: ""
+      # -- Azure Active Directory tenant ID of the target Key Vault
+      tenantId: ""
+    resourceManager:
+      # -- Subscription ID of the target Azure Key Vault
+      subscriptionId: ""
+      # -- Name of the Azure Resource Group to which the target Azure Key Vault belongs
+      resourceGroup: ""
+  serviceAccount: "wso2am-all-in-one-svc-account"
+  persistence:
+    # Needed for persisting indexing related data
+    # -- Persistent volume capacity
+    capacity: ""
+    # -- Persistent volume storage class
+    storageClass: ""
+    # -- Azure file secret name
+    secretName: ""
+    # -- Azure fileshare name
+    fileShare: ""
+
+# Google Cloud Platform (GCP) integration status
+gcp:
+  # -- If GCP is used as the cloud provider
+  enabled: true
+  # -- File Store configuration parameters
+  fs:
+    # -- Storage capacity of the file system (in GB or other appropriate units)
+    capacity: ""
+    # -- FileStore configuration for specific services
+    fileshares:
+      # -- FileShare configs for CarbonDB persistent storage
+      carbonDB:
+        # -- FileStore of the CarbonDB persistent storage
+        fileStoreName: ""
+        # -- FileShare of the CarbonDB persistent storage
+        fileShareName: ""
+        # -- IP of the CarbonDB persistent storage
+        ip: ""
+      # -- FileShare configs for Solr persistent storage
+      solr:
+        # -- FileStore of the Solr persistent storage
+        fileStoreName: ""
+        # -- FileShare of the Solr persistent storage
+        fileShareName: ""
+        # -- IP of the Solr persistent storage
+        ip: ""
+    # -- Tier of the FileStore
+    tier: ""
+    # -- Network of the FileStore
+    network: ""
+
+    # -- Region of the FileStore
+    location: ""
+
+  # -- Secrets Manager configuration parameters
+  secretsManager:
+    # -- Project ID
+    projectId: ""
+    # -- Secret provider class
+    secretProviderClass: ""
+    secret:
+      # -- Name of the secret
+      secretName: ""
+      # -- Version of the secret
+      secretVersion: ""
+  # -- Service Account with access to read secrets
+  serviceAccountName: ""
+
+kubernetes:
+  # -- Ingress class to be used for the ingress resource
+  ingressClass: "nginx"
+  ingress:
+    # -- Kubernetes secret created for Ingress TLS
+    tlsSecret: ""
+    ratelimit:
+      # -- Ingress rate limit
+      enabled: false
+      # -- Ingress ratelimit zone name
+      zoneName: ""
+      # -- Ingress ratelimit burst limit
+      burstLimit: ""
+    management:
+      enabled: true
+      # Hostname for API Manager Carbon Management Console, Publisher, DevPortal and Admin Portal
+      hostname: "am.wso2.com"
+      # Annotations for the API Manager Publisher-DevPortal services Ingress
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+        nginx.ingress.kubernetes.io/affinity: "cookie"
+        nginx.ingress.kubernetes.io/session-cookie-name: "route"
+        nginx.ingress.kubernetes.io/session-cookie-hash: "sha1"
+    gateway:
+      enabled: true
+      # -- Ingress hostname for Gateway pass-through
+      hostname: "gw.wso2.com"
+      # -- Ingress annotations for Gateway pass-through
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+        nginx.ingress.kubernetes.io/proxy-buffering: "on"
+        nginx.ingress.kubernetes.io/proxy-buffer-size: "8k"
+    websocket:
+      enabled: true
+      # -- Ingress hostname for Websocket
+      hostname: "websocket.wso2.com"
+      # -- Ingress annotations for Websocket
+      annotations:
+        #todo: add websocket specific annotations
+    websub:
+      enabled: true
+      # -- Ingress hostname for Websub
+      hostname: "websub.wso2.com"
+      # -- Ingress annotations for Websub
+      annotations:
+  securityContext:
+    # -- User ID of the container
+    runAsUser: 802
+    runAsGroup: 802
+
+
+wso2:
+  # -- WSO2 Choreo Analytics Parameters
+  # If provided, these parameters will be used publish analytics data to Choreo Analytics environment (https://apim.docs.wso2.com/en/latest/observe/api-manager-analytics/configure-analytics/register-for-analytics/).
+  choreoAnalytics:
+    enabled: false
+    # -- Choreo Analytics cloud service endpoint
+    endpoint: ""
+    # -- On-premise key for Choreo Analytics
+    onpremKey: ""
+
+  # -- ELK Analytics Parameters
+  ELKAnalytics:
+    enabled: false
+
+  # TOML configurations
+  apim:
+    # -- APIM version
+    version: "4.3.0"
+    # -- Secure vauld enabled
+    secureVaultEnabled: false
+    # Logging related configurations
+    log4j2:
+      # -- Console loggers that can be enabled. Allowed values are AUDIT_LOG_CONSOLE, HTTP_ACCESS_CONSOLE, TRANSACTION_CONSOLE, CORRELATION_CONSOLE
+      loggers: ""
+      # -- Appenders
+      appenders: ""
+    # -- Startup arguments for APIM
+    startupArgs: ""
+    # -- Port Offset for APIM deployment
+    portOffset: 0
+    # -- Startup script mount status
+    mountStartupScript: false
+    # TOML configurations
+    configurations:
+      gatewayType: "Regular,APK"
+      userStore:
+        # -- User store type.
+        # https://apim.docs.wso2.com/en/latest/administer/managing-users-and-roles/managing-user-stores/configure-primary-user-store/configuring-the-primary-user-store/
+        type: "database_unique_id"
+        # -- User store properties
+        properties:
+          # key: value
+      # -- Super admin username
+      adminUsername: "admin"
+      # -- Super admin password
+      adminPassword: "admin"
+      databases:
+        # -- Database type. eg: mysql, oracle, mssql, postgres
+        type: "h2"
+        jdbc:
+          # -- JDBC driver class name
+          driver: "org.h2.Driver"
+        # -- APIM APIMDB configurations. This is required for gateway only in a multi-tenancy scenario
+        apim_db:
+          # -- APIM APIMDB URL
+          url: "jdbc:h2:./repository/database/WSO2AM_DB;DB_CLOSE_ON_EXIT=FALSE"
+          # -- APIM APIMDB username
+          username: "wso2carbon"
+          # -- APIM APIMDB password
+          password: "wso2carbon"
+          # -- APIM database JDBC pool parameters
+          poolParameters:
+            defaultAutoCommit: false
+            testOnBorrow: true
+            testWhileIdle: true
+            validationInterval: 30000
+            maxActive: 100
+            maxWait: 60000
+            minIdle: 5
+        shared_db:
+          # -- APIM SharedDB URL
+          url: "jdbc:h2:./repository/database/WSO2SHARED_DB;DB_CLOSE_ON_EXIT=FALSE"
+          # -- APIM SharedDB username
+          username: "wso2carbon"
+          # -- APIM SharedDB password
+          password: "wso2carbon"
+          # -- APIM database JDBC pool parameters
+          poolParameters:
+            defaultAutoCommit: false
+            testOnBorrow: true
+            testWhileIdle: true
+            validationInterval: 30000
+            maxActive: 100
+            maxWait: 60000
+            minIdle: 5
+
+      # -- APIM AI related configurations
+      ai:
+        enabled: false
+        token: ""
+        endpoint: ""
+
+      security:
+        # -- Kubernetes secret containing the keystores and truststore
+        jksSecretName: ""
+        keystores:
+          primary:
+            # -- Primary keystore enabled
+            enabled: false
+            # -- Primary keystore name
+            name: "wso2carbon.jks"
+            # -- Primary keystore alias
+            alias: "wso2carbon"
+            # -- Primary keystore password
+            password: "wso2carbon"
+            # -- Primary keystore key password
+            keyPassword: "wso2carbon"
+          tls:
+            # -- TLS keystore enabled
+            enabled: true
+            # -- TLS keystore name
+            name: "wso2carbon.jks"
+            # -- TLS keystore alias
+            alias: "wso2carbon"
+            # -- TLS keystore password
+            password: "wso2carbon"
+            # -- TLS keystore key password
+            keyPassword: "wso2carbon"
+          internal:
+            # -- Internal keystore enabled
+            enabled: false
+            # -- Internal keystore name
+            name: "wso2carbon.jks"
+            # -- Internal keystore alias
+            alias: "wso2carbon"
+            # -- Internal keystore password
+            password: "wso2carbon"
+            # -- Internal keystore key password
+            keyPassword: "wso2carbon"
+        truststore:
+          # -- Truststore name
+          name: "client-truststore.jks"
+          # -- Truststore password
+          password: "wso2carbon"
+
+      gateway:
+        # -- APIM Gateway environments
+        environments:
+        - name: "Default"
+          type: "hybrid"
+          gatewayType: "Regular"
+          provider: "wso2"
+          displayInApiConsole: true
+          description: "This is a hybrid gateway that handles both production and sandbox token traffic."
+          showAsTokenEndpointUrl: true
+          serviceName: "wso2am-gateway-service"
+          servicePort: 9443
+          wsHostname: "websocket.wso2.com"
+          httpHostname: "gw.wso2.com"
+          websubHostname: "websub.wso2.com"
+        #   gatewayType: "APK"
+        #   provider: "wso2"
+        #   displayInApiConsole: true
+        #   description: "This is a hybrid gateway that handles both production and sandbox token traffic."
+        #   showAsTokenEndpointUrl: true
+        #   serviceName: "wso2am-gateway-service"
+        #   servicePort: 9443
+        #   wsHostname: "websocket.wso2.com"
+        #   httpHostname: "default.gw.wso2.com:9095"
+        #   websubHostname: "websub.wso2.com"
+        # - name: "Default_synapse"
+        #   type: "hybrid"          
+
+      syncRuntimeArtifacts:
+        gateway:
+          # -- Gateway label used to filter out artifact retrieval
+          labels: ["Default"]
+
+      iskm:
+        # If Identity Server is used as the Resident KM
+        enabled: false
+        # Kubernetes service name exposing Identity Server
+        serviceName: ""
+        # Revoke URL of Identity Server
+        revokeURL: ""
+
+      jwt:
+        # Enable backend JWT generation in gateway
+        enabled: false
+        # JWT encoding algorithm. Can be either base64 or base64url
+        encoding: "base64"
+        # JWT header name.
+        header: "X-JWT-Assertion"
+        # JWT claim dialect
+        claimDialect: "http://wso2.org/claims"
+        # JWT signature algorithm. SHA256withRSA
+        signingAlgorithm: "SHA256withRSA"
+        # JWT generation implementation.
+        generatorImpl: "org.wso2.carbon.apimgt.keymgt.token.JWTGenerator"
+        # Enable end user claim mapping
+        enableUserClaims: "false"
+        # JWT claims extractor implementation. eg: org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever
+        claimsExtractorImpl: "org.wso2.carbon.apimgt.impl.token.DefaultClaimsRetriever"
+
+      # APIM cache related configurations
+      cache:
+        gateway_token:
+          # -- Gateway token cache enabled
+          enabled: true
+          # -- Gateway token cache expiration time
+          expiryTime: "15m"
+        resource:
+          # -- Gateway resource cache enabled
+          enabled: true
+          # -- Gateway resource cache expiration time
+          expiryTime: "900s"
+        km_token:
+          # -- Gateway KM token cache enabled
+          enabled: true
+          # -- Gateway KM token cache expiration time
+          expiryTime: "15m"
+        recent_apis:
+          # -- Gateway recent APIs cache enabled
+          enabled: false
+        scopes:
+          enabled: false
+        publisher_roles:
+          enabled: false
+        jwt_claim:
+          # -- Gateway JWT claim cache enabled
+          enabled: true
+          # -- Gateway JWT claim cache expiration time
+          expiryTime: "15m"
+        tags:
+          # -- Gateway tags cache enabled
+          enabled: true
+          expiryTime: "2m"
+
+      # APIM OAuth configurations
+      oauth_config:
+        # -- Remove auth header from outgoing requests
+        removeOutboundAuthHeader: true
+        # -- OAuth authorization header name
+        authHeader: "Authorization"
+        # -- OAuth revoke endpoint
+        revokeEndpoint: ""
+        # -- Enable token encryption
+        enableTokenEncryption: false
+        # -- Enable token hashing
+        enableTokenHashing: false
+        oauth2JWKSUrl: "https://wso2-apim-am-all-in-one-am-service:9443/oauth2/jwks"
+
+      # APIM Devportal configurations
+      devportal:
+        enableApplicationSharing:
+        applicationSharingType:
+        applicationSharingImpl:
+        # -- Whether to display multiple versions of same API or only showing the latest version of an API
+        displayMultipleVersions:
+        # -- Whether to display deprecated APIs
+        displayDeprecatedApis:
+        # -- Whether to display comments for API
+        enableComments:
+        # -- Whether to display ratings for API
+        enableRatings:
+        # -- Whether to display forum for API
+        enableForum:
+        # -- Whether anonymous mode is enabled
+        enableAnonymousMode:
+        enableCrossTenantSubscriptions:
+        defaultReservedUsername:
+        # -- Whether to create default application
+        create_default_application:
+        loginUsernameCaseInsensitive:
+        enableKeyProvisioning:
+
+      publisher:
+        # -- Supported document types in Publisher.
+        # This should be used only if there are additional document types to be supported.
+        supportedDocumentTypes: ""
+        enablePortalConfigurationOnlyMode: false
+        internalKeyIssuer: "http://am.wso2.com:443/token"
+
+      # APIM CORS configurations
+      cors:
+        # -- CORS configuration enabled
+        enabled: true
+        # -- CORS Access-Control-Allow-Origin
+        allowOrigins: ["*"]
+        # -- CORS Access-Control-Allow-Methods
+        allowMethods: ["GET","PUT","POST","DELETE","PATCH","OPTIONS"]
+        # -- CORS Access-Control-Allow-Headers
+        allowHeaders: ["authorization","Access-Control-Allow-Origin","Content-Type","SOAPAction","apikey","Internal-Key"]
+        # -- CORS Access-Control-Allow-Credentials
+        allowCredentials: false
+        # -- Enable CORS for Websockets
+        enableForWS: false
+
+      throttling:
+        enableDataPublishing: true
+        enablePolicyDeploy: true
+        enableBlacklistCondition: true
+        enablePersistence: true
+        throttleDecisionEndpoints: []
+        enableUnlimitedTier: true
+        enableHeaderBasedThrottling: false
+        enableJwtClaimBasedThrottling: false
+        enableQueryParamBasedThrottling: false
+        blacklistCondition:
+          startDelay:
+          period:
+        jms:
+          startDelay:
+        eventSync:
+          hostname:
+          port:
+        eventManagement:
+          hostname:
+          port:
+
+      workflow:
+        enable: false
+        serviceUrl: ""
+        callbackEndpoint: ""
+        tokenEndpoint: ""
+        clientRegistrationEndpoint: ""
+
+      transport:
+        receiver:
+          type: ""
+          workerThreads: 10
+          sessionTimeout: ""
+          keystore:
+            fileName: "$ref{keystore.tls.file_name}"
+            password: "$ref{keystore.tls.password}"
+          tcpPort: 9611
+          sslPort: 9711
+          sslReceiverThreadPoolSize: 100
+          tcpReceiverThreadPoolSize: 100
+          sslEnabledProtocols:
+            - "TLSv1"
+            - "TLSv1.1"
+            - "TLSv1.2"
+          ciphers:
+            - "SSL_RSA_WITH_RC4_128_MD5"
+            - "SSL_RSA_WITH_RC4_128_SHA"
+
+      token:
+        revocation:
+          NotifierImpl: "org.wso2.carbon.apimgt.keymgt.events.TokenRevocationNotifierImpl"
+          EnableRealtimeNotifier: true
+          RealtimeNotifierTtl: 5000
+          EnablePersistentNotifier: true
+          PersistentNotifierHostname: "https://localhost:2379/v2/keys/jti/"
+          PersistentNotifierTtl: 5000
+          PersistentNotifierUsername: "root"
+          PersistentNotifierPassword: "root"
+
+      notification:
+        fromAddress:
+        username:
+        password:
+        signature:
+        hostname:
+        port: 25
+        enableStartTls: false
+        enableAuthentication: false
+
+      eventHandlers:
+        - name: "userPostSelfRegistration"
+          subscriptions:
+            - "POST_ADD_USER"
+
+      serviceProvider:
+        spNameRegex: "^[\\sa-zA-Z0-9._-]*$"
+
+      eventListeners:
+        - id: "token_revocation"
+          type: "org.wso2.carbon.identity.core.handler.AbstractIdentityHandler"
+          name: "org.wso2.is.notification.ApimOauthEventInterceptor"
+          order: 1
+          properties:
+            notificationEndpoint: "https://localhost:${mgt.transport.https.port}/internal/data/v1/notify"
+
+  deployment:
+    # Container image configurations
+    image:
+      # -- Registry containing the image
+      registry: "docker.io"
+      # -- Repository name consisting the image
+      repository: "wso2/wso2am"
+      # -- Docker image digest
+      digest: "sha256:7d6ec26a396dc81b9bf06e7d03cc41d1c46e3199a0db6e19dde68673fbe53c3a"
+      # -- Refer to the Kubernetes documentation on updating images (https://kubernetes.io/docs/concepts/containers/images/#updating-images)
+      imagePullPolicy: Always
+
+    resources:
+      # These are the resource recommendations for running WSO2 API Management product profiles with profile optimization
+      # Resource configurations defined here are applicable for all API Manager product profiles of this deployment
+      requests:
+        # -- Memory request for API Manager
+        memory: "2Gi"
+        # -- CPU request for API Manager
+        cpu: "2000m"
+      limits:
+        # -- Memory limit for API Manager
+        memory: "3Gi"
+        # -- CPU limit for API Manager
+        cpu: "3000m"
+      jvm:
+        memory:
+          # -- JVM heap memory Xms
+          xms: "2048m"
+          # -- JVM heap memory Xmx
+          xmx: "2048m"
+
+    # Kubernetes Probes
+    # Indicates whether the container starting
+    startupProbe:
+      # -- Number of seconds after the container has started before startup probes are initiated
+      initialDelaySeconds: 60
+      # -- How often (in seconds) to perform the probe
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      failureThreshold: 5
+    # Indicates whether the container is running
+    livenessProbe:
+      # -- Number of seconds after the container has started before liveness probes are initiated
+      initialDelaySeconds: 60
+      # -- How often (in seconds) to perform the probe
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      failureThreshold: 5
+    # Indicates whether the container is ready to service requests
+    readinessProbe:
+      # -- Number of seconds after the container has started before readiness probes are initiated
+      initialDelaySeconds: 60
+      # -- How often (in seconds) to perform the probe
+      periodSeconds: 10
+      # -- Minimum consecutive successes for the probe to be considered successful after having failed
+      failureThreshold: 5
+    lifecycle:
+      preStopHook:
+        # -- Time to wait until the apim is terminated gracefully
+        sleepSeconds: 10
+
+    # -- Minimum available pod counts for PDB
+    minAvailable: "50%"
+
+    # -- Node selector to deploy pod in selected node. Add label to the node and specify the label here.
+    nodeSelector:
+
+    persistence:
+      # -- Persistent runtime artifacts for Apache Solr-based indexing
+      solrIndexing:
+        # -- Indicates if persistence of the runtime artifacts for Apache Solr-based indexing is enabled
+        # By default, this is disabled
+        enabled: false
+        # Define capacities for persistent runtime artifact directories
+        capacity:
+          # -- For persisting the H2 based local Carbon database file
+          carbonDatabase: 50M
+          # -- For persisting the indexed solr data
+          solrIndexedData: 50M


### PR DESCRIPTION
## Purpose
> $Subject. 

- This adds artifacts for WSO2 APIM all-in-one deployment under `samples/deployment/apim/all-in-one` directory.
- This creates a new index pattern `wso2-apim-application-logs-*` for APIM logs.
- The log4j2.properties file used by default in APIM, has been modified to redirect to the console. Therefore, console appenders have been added for AUDIT, CORRELATION, TRACE and HTTP logs
