### PR TITLE
Improve log configs for WSO2 APIM

### DIFF
--- a/observability/deployment/fluent-bit.yaml
+++ b/observability/deployment/fluent-bit.yaml
@@ -104,19 +104,19 @@ config:
             Preserve_Key True
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match kube.*
             Rule $kubernetes['labels']['component'] wso2apim wso2_apim_logs false
             Emitter_Name re_emitted_apim
 
         [FILTER]
-            Name modify_apim
+            Name modify
             Match wso2_apim_logs
             Add product api-management
             Add component apim
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match wso2_apim_logs
             Rule $log ^CARBON wso2_apim_carbon_logs false
             Emitter_Name re_emitted_apim_carbon
@@ -154,25 +154,25 @@ config:
             Emitter_Name re_emitted_mi_trace
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match wso2_apim_logs
             Rule $log ^HTTP wso2_apim_http_logs false
             Emitter_Name re_emitted_apim_http
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match wso2_apim_logs
             Rule $log ^AUDIT wso2_apim_audit_logs false
             Emitter_Name re_emitted_apim_audit
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match wso2_apim_logs
             Rule $log ^CREL wso2_apim_correlation_logs false
             Emitter_Name re_emitted_apim_correlation
 
         [FILTER]
-            Name rewrite_tag_apim
+            Name rewrite_tag
             Match wso2_apim_logs
             Rule $log ^TRACE wso2_apim_trace_logs false
             Emitter_Name re_emitted_apim_trace

--- a/samples/deployment/apim/all-in-one/confs/deployment.toml
+++ b/samples/deployment/apim/all-in-one/confs/deployment.toml
@@ -7,8 +7,8 @@ base_path = "${carbon.protocol}://${carbon.host}:${carbon.management.port}"
 #discard_empty_caches = false
 server_role = "default"
 
-[http_access_log]
-enabled = true
+[n_http]
+"nhttp.is.log.rotatable" = "true"
 
 [user_store]
 type = {{ .Values.wso2.apim.configurations.userStore.type | quote }}

--- a/samples/deployment/apim/all-in-one/confs/log4j2.properties
+++ b/samples/deployment/apim/all-in-one/confs/log4j2.properties
@@ -1,6 +1,6 @@
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, AUDIT_CONSOLE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_TRACE_CONSOLE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, CORRELATION_CONSOLE, BOTDATA_APPENDER, API_LOGFILE, HTTP_ACCESS, HTTP_ACCESS_CONSOLE
+appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, AUDIT_CONSOLE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_TRACE_CONSOLE, ERROR_LOGFILE, OPEN_TRACING,SERVICE_APPENDER, TRACE_APPENDER, osgi, CORRELATION, CORRELATION_CONSOLE, BOTDATA_APPENDER, API_LOGFILE, PassThroughAccess_LOGFILE, HTTP_ACCESS_CONSOLE
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -205,37 +205,37 @@ appender.SERVICE_APPENDER.policies.size.size=1000KB
 appender.SERVICE_APPENDER.strategy.type = DefaultRolloverStrategy
 appender.SERVICE_APPENDER.strategy.max = 10
 
-appender.HTTP_ACCESS.type = RollingFile
-appender.HTTP_ACCESS.name = HTTP_ACCESS
-appender.HTTP_ACCESS.fileName =${sys:carbon.home}/repository/logs/wso2carbon.log
-appender.HTTP_ACCESS.filePattern =${sys:carbon.home}/repository/logs/wso2carbon-%d{MM-dd-yyyy}.log
-appender.HTTP_ACCESS.layout.type = PatternLayout
-appender.HTTP_ACCESS.layout.pattern = [%X{Correlation-ID}] %mm%n
-appender.HTTP_ACCESS.policies.type = Policies
-appender.HTTP_ACCESS.policies.time.type = TimeBasedTriggeringPolicy
-appender.HTTP_ACCESS.policies.time.interval = 1
-appender.HTTP_ACCESS.policies.time.modulate = true
-appender.HTTP_ACCESS.policies.size.type = SizeBasedTriggeringPolicy
-appender.HTTP_ACCESS.policies.size.size=10MB
-appender.HTTP_ACCESS.strategy.type = DefaultRolloverStrategy
-appender.HTTP_ACCESS.strategy.max = 20
-appender.HTTP_ACCESS.filter.threshold.type = ThresholdFilter
-appender.HTTP_ACCESS.filter.threshold.level = INFO
+appender.PassThroughAccess_LOGFILE.type = RollingFile
+appender.PassThroughAccess_LOGFILE.name = PassThroughAccess_LOGFILE
+appender.PassThroughAccess_LOGFILE.fileName =${sys:carbon.home}/repository/logs/http_gw.log
+appender.PassThroughAccess_LOGFILE.filePattern =${sys:carbon.home}/repository/logs/http_gw-%d{yyyy-MM-dd}-%i.log
+appender.PassThroughAccess_LOGFILE.layout.type = PatternLayout
+appender.PassThroughAccess_LOGFILE.layout.pattern = %msg%n
+appender.PassThroughAccess_LOGFILE.policies.type = Policies
+appender.PassThroughAccess_LOGFILE.policies.time.type = TimeBasedTriggeringPolicy
+appender.PassThroughAccess_LOGFILE.policies.time.interval = 1
+appender.PassThroughAccess_LOGFILE.policies.time.modulate = true
+appender.PassThroughAccess_LOGFILE.policies.size.type = SizeBasedTriggeringPolicy
+appender.PassThroughAccess_LOGFILE.policies.size.size=100kB
+appender.PassThroughAccess_LOGFILE.strategy.type = DefaultRolloverStrategy
+appender.PassThroughAccess_LOGFILE.strategy.max = 20
+appender.PassThroughAccess_LOGFILE.filter.threshold.type = ThresholdFilter
+appender.PassThroughAccess_LOGFILE.filter.threshold.level = DEBUG
 
 # Appender config for Http access console
 appender.HTTP_ACCESS_CONSOLE.type = Console
 appender.HTTP_ACCESS_CONSOLE.name = HTTP_ACCESS_CONSOLE
 appender.HTTP_ACCESS_CONSOLE.layout.type = PatternLayout
-# appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP %msg%n
-appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP [%X{Correlation-ID}] %mm%n
+appender.HTTP_ACCESS_CONSOLE.layout.pattern = HTTP %msg%n
 appender.HTTP_ACCESS_CONSOLE.filter.threshold.type = ThresholdFilter
 appender.HTTP_ACCESS_CONSOLE.filter.threshold.level = DEBUG
+
 
 appender.osgi.type = PaxOsgi
 appender.osgi.name = PaxOsgi
 appender.osgi.filter = *
 
-loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG, HTTP_ACCESS, synapse-wire
+loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-CsrfGuard, org-apache-axis2-wsdl-codegen-writer-PrettyPrinter, org-apache-axis2-clustering, org-apache-catalina, org-apache-tomcat, org-wso2-carbon-apacheds, org-apache-directory-server-ldap, org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, trace, synapse, synapse_transport, axis2, axis2_transport, org-wso2-carbon, hunsicker, thrift-publisher, service_logger, trace_logger, org-wso2-carbon-apimgt-gateway-mediators-BotDetectionMediator, wso2-callhome, correlation, API_LOG, synapse-wire, PassThroughAccess
 
 logger.API_LOG.name = API_LOG
 logger.API_LOG.level = INFO
@@ -253,12 +253,6 @@ logger.trace-messages.name = trace.messages
 logger.trace-messages.level = TRACE
 logger.trace-messages.appenderRef.CARBON_TRACE_LOGFILE.ref = CARBON_TRACE_LOGFILE
 logger.trace-messages.appenderRef.CARBON_TRACE_CONSOLE.ref = CARBON_TRACE_CONSOLE
-
-logger.HTTP_ACCESS.name = HTTP_ACCESS
-logger.HTTP_ACCESS.level = INFO
-logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS.ref = HTTP_ACCESS
-logger.HTTP_ACCESS.appenderRef.HTTP_ACCESS_CONSOLE.ref = HTTP_ACCESS_CONSOLE
-logger.HTTP_ACCESS.additivity = false
 
 logger.org-apache-coyote.name = org.apache.coyote
 logger.org-apache-coyote.level = WARN
@@ -389,6 +383,14 @@ logger.correlation.level = INFO
 logger.correlation.appenderRef.CORRELATION.ref = CORRELATION
 logger.correlation.appenderRef.CORRELATION_CONSOLE.ref = CORRELATION_CONSOLE
 logger.correlation.additivity = false
+
+# HTTP Access Logs
+logger.PassThroughAccess.name = org.apache.synapse.transport.nhttp.access
+logger.PassThroughAccess.level = DEBUG
+logger.PassThroughAccess.appenderRef.PassThroughAccess_LOGFILE.ref = PassThroughAccess_LOGFILE
+logger.PassThroughAccess.appenderRef.HTTP_ACCESS_CONSOLE.ref = HTTP_ACCESS_CONSOLE
+logger.PassThroughAccess.additivity = false
+
 
 # Hive Related Log configurations
 logger.DataNucleus.name = DataNucleus

--- a/samples/deployment/apim/all-in-one/confs/log4j2.properties
+++ b/samples/deployment/apim/all-in-one/confs/log4j2.properties
@@ -7,7 +7,7 @@ appenders=CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, AUDIT_CONSOLE, ATOMIKOS
 appender.CARBON_CONSOLE.type = Console
 appender.CARBON_CONSOLE.name = CARBON_CONSOLE
 appender.CARBON_CONSOLE.layout.type = PatternLayout
-appender.CARBON_CONSOLE.layout.pattern = CARBON [%d{DEFAULT}] %5p - %c{1} %m%n
+appender.CARBON_CONSOLE.layout.pattern = CARBON [%d] %5p {%c{1}} %X{Artifact-Container} - %m%ex%n
 appender.CARBON_CONSOLE.filter.threshold.type = ThresholdFilter
 appender.CARBON_CONSOLE.filter.threshold.level = DEBUG
 


### PR DESCRIPTION
## Purpose
- Add HTTP Access log configs for WSO2 APIM.
- Modify the `CARBON_CONSOLE` log format, so that the `wso2apim_carbon_parser` works appropriately.